### PR TITLE
AA-231 minor fix due to some problems with using concurrenthashmaps 

### DIFF
--- a/ShimmerDriver/src/main/java/com/shimmerresearch/driverUtilities/SensorDetails.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/driverUtilities/SensorDetails.java
@@ -20,7 +20,7 @@ public class SensorDetails implements Serializable{
 	private static final long serialVersionUID = 1545530433767674139L;
 	
 	/** by default load in communication types for Bluetooth and SD	 */
-	public ConcurrentHashMap<COMMUNICATION_TYPE, Boolean> mapOfIsEnabledPerCommsType = new ConcurrentHashMap<COMMUNICATION_TYPE, Boolean>();
+	public Map<COMMUNICATION_TYPE, Boolean> mapOfIsEnabledPerCommsType = new ConcurrentHashMap<COMMUNICATION_TYPE, Boolean>();
 	{
 		mapOfIsEnabledPerCommsType.put(COMMUNICATION_TYPE.BLUETOOTH, false);
 		mapOfIsEnabledPerCommsType.put(COMMUNICATION_TYPE.SD, false);


### PR DESCRIPTION
 minor fix due to some problems with using concurrenthashmaps on Android.

@RuMolloy @marknolan asking you guys for review, just so you will be aware of the issue. not sure if there are any other better fixes.

I am noting the following so i can create the release tag in the future
0.9.127beta_AA-230 (ShimmerDriver)
0.9.39beta_AA-230 (ShimmerBluetoothManager)