### PR TITLE
DEV-341 fix for unknown charger chip status via dock

### DIFF
--- a/ShimmerDriver/src/main/java/com/shimmerresearch/driverUtilities/ShimmerBattStatusDetails.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/driverUtilities/ShimmerBattStatusDetails.java
@@ -75,7 +75,8 @@ public class ShimmerBattStatusDetails implements Serializable {
 		if(rxBuf.length >= 3) {
 			// Parse response string
             int battAdcValue = (((rxBuf[1]&0xFF) << 8) + (rxBuf[0]&0xFF));
-            int chargingStatus = rxBuf[2] & 0xC0;
+            // Parse as unsigned byte and let full byte through to handle UNKNOWN status
+            int chargingStatus = rxBuf[2] & 0xFF; 
             update(battAdcValue, chargingStatus);
 		}
 	}


### PR DESCRIPTION
When a Shimmer is docked, the charger chip status is unknown for a short period of time. This state was being filter from dock communication but not BT communication. When the Shimmer was in this state, Consensys was mistakenly reporting the unit as being charging suspended (0xC0) instead of unknown (0xFF).