### PR TITLE
DEV-737 change default USB speed and value

### DIFF
--- a/ShimmerDriver/src/main/java/com/shimmerresearch/driverUtilities/EepromSensorSettingsDetails.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/driverUtilities/EepromSensorSettingsDetails.java
@@ -14,7 +14,7 @@ public class EepromSensorSettingsDetails implements Serializable {
 	public int radioHwVer = 0;
 	public int baudRate = 0;
 	public BTRADIO_STATE mRadioState = BTRADIO_STATE.BT_CLASSIC_BLE_ENABLED; 
-	public boolean mUsbFullSpeed = true; 
+	public boolean mUsbHighSpeed = true; 
 
 	public enum EXP_BOARD_ARRAY_BYTE_INDEX {
 		RADIO_HW_VER,
@@ -67,8 +67,8 @@ public class EepromSensorSettingsDetails implements Serializable {
 	}
 	
 	public enum USB_SPEED {
-		FULL_SPEED("Full-Speed", 0x04),
-		HIGH_SPEED("High-Speed", 0x00);
+		HIGH_SPEED("High-Speed (480 Mbps)", 0x04),
+		FULL_SPEED("Full-Speed (12 Mbps)", 0x00);
 		
 	    private String text;
 		private int bits;
@@ -116,12 +116,12 @@ public class EepromSensorSettingsDetails implements Serializable {
 	        mRadioState = BTRADIO_STATE.NONE_ENABLED;
 	    }
 
-	    mUsbFullSpeed = (mEepromPageArray[EXP_BOARD_ARRAY_BYTE_INDEX.SENSOR_OPTIONS1.ordinal()] & USB_SPEED.FULL_SPEED.getBitValue()) != 0;
+	    mUsbHighSpeed = (mEepromPageArray[EXP_BOARD_ARRAY_BYTE_INDEX.SENSOR_OPTIONS1.ordinal()] & USB_SPEED.HIGH_SPEED.getBitValue()) != 0;
 	}
 
 	public String generateDebugString() {
 		return (mRadioState.toString() + ", USB Speed: " 
-	+ (mUsbFullSpeed == true ? USB_SPEED.FULL_SPEED.toString() : USB_SPEED.HIGH_SPEED.toString()));
+	+ (mUsbHighSpeed == true ? USB_SPEED.HIGH_SPEED.toString() : USB_SPEED.FULL_SPEED.toString()));
 	}
 
 	public void setBtRadioStateFromString(String option) {
@@ -137,10 +137,10 @@ public class EepromSensorSettingsDetails implements Serializable {
 	}
 
 	public void setUsbSpeedStateFromString(String option) {
-		if (option.equals(USB_SPEED.FULL_SPEED.toString())) {
-			mUsbFullSpeed = true;
-		} else if (option.equals(USB_SPEED.HIGH_SPEED.toString())) {
-			mUsbFullSpeed = false;
+		if (option.equals(USB_SPEED.HIGH_SPEED.toString())) {
+			mUsbHighSpeed = true;
+		} else if (option.equals(USB_SPEED.FULL_SPEED.toString())) {
+			mUsbHighSpeed = false;
 		}
 		
 		updateEepromPageArray();
@@ -154,7 +154,7 @@ public class EepromSensorSettingsDetails implements Serializable {
 		mEepromPageArray[EXP_BOARD_ARRAY_BYTE_INDEX.SENSOR_OPTIONS1.ordinal()] |= mRadioState.getBitValue(); // Set the new radio state bits
 
 		mEepromPageArray[EXP_BOARD_ARRAY_BYTE_INDEX.SENSOR_OPTIONS1.ordinal()] &= 0xFB; // Clear the existing USB speed bit (bit 2)
-		mEepromPageArray[EXP_BOARD_ARRAY_BYTE_INDEX.SENSOR_OPTIONS1.ordinal()] |= (mUsbFullSpeed ? USB_SPEED.FULL_SPEED.getBitValue() : USB_SPEED.HIGH_SPEED.getBitValue()); // Set the new USB speed bit
+		mEepromPageArray[EXP_BOARD_ARRAY_BYTE_INDEX.SENSOR_OPTIONS1.ordinal()] |= (mUsbHighSpeed ? USB_SPEED.HIGH_SPEED.getBitValue() : USB_SPEED.FULL_SPEED.getBitValue()); // Set the new USB speed bit
 	}
 
 }

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/driverUtilities/EepromSensorSettingsDetails.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/driverUtilities/EepromSensorSettingsDetails.java
@@ -121,7 +121,7 @@ public class EepromSensorSettingsDetails implements Serializable {
 
 	public String generateDebugString() {
 		return (mRadioState.toString() + ", USB Speed: " 
-	+ (mUsbHighSpeed == true ? USB_SPEED.HIGH_SPEED.toString() : USB_SPEED.FULL_SPEED.toString()));
+	+ (mUsbHighSpeed ? USB_SPEED.HIGH_SPEED.toString() : USB_SPEED.FULL_SPEED.toString()));
 	}
 
 	public void setBtRadioStateFromString(String option) {


### PR DESCRIPTION
This pull request updates how USB speed settings are represented and managed in the `EepromSensorSettingsDetails` class. The main change is a shift from using a `mUsbFullSpeed` boolean to a `mUsbHighSpeed` boolean, along with clarifying the meaning and bit values for USB speed options. These changes improve code clarity and ensure correct mapping between the boolean state and the USB speed configuration.

**USB Speed Handling Updates:**

* Replaced the `mUsbFullSpeed` boolean with `mUsbHighSpeed` throughout the class to more accurately reflect the intended USB speed state. [[1]](diffhunk://#diff-48754f3a2f0297df0a48959dab36e87a33a79e0a071d3ff72c44a09f9864a1afL17-R17) [[2]](diffhunk://#diff-48754f3a2f0297df0a48959dab36e87a33a79e0a071d3ff72c44a09f9864a1afL119-R124) [[3]](diffhunk://#diff-48754f3a2f0297df0a48959dab36e87a33a79e0a071d3ff72c44a09f9864a1afL140-R143) [[4]](diffhunk://#diff-48754f3a2f0297df0a48959dab36e87a33a79e0a071d3ff72c44a09f9864a1afL157-R157)
* Updated the `USB_SPEED` enum to clarify speed names and bit values: `HIGH_SPEED` now represents 480 Mbps with bit value `0x04`, and `FULL_SPEED` is 12 Mbps with bit value `0x00`.
* Adjusted logic in methods such as `parseEepromSensorSettingsDetails`, `generateDebugString`, `setUsbSpeedStateFromString`, and `updateEepromPageArray` to use the new `mUsbHighSpeed` field and the revised enum values, ensuring correct USB speed setting and reporting. [[1]](diffhunk://#diff-48754f3a2f0297df0a48959dab36e87a33a79e0a071d3ff72c44a09f9864a1afL119-R124) [[2]](diffhunk://#diff-48754f3a2f0297df0a48959dab36e87a33a79e0a071d3ff72c44a09f9864a1afL140-R143) [[3]](diffhunk://#diff-48754f3a2f0297df0a48959dab36e87a33a79e0a071d3ff72c44a09f9864a1afL157-R157)