### PR TITLE
DEV-793 Add 2nd-gen Verisense LSM6DSV IMU file-parser support

### DIFF
--- a/ShimmerDriver/src/main/java/com/shimmerresearch/driver/Configuration.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/driver/Configuration.java
@@ -2639,6 +2639,14 @@ public class Configuration {
 			public static final int MAX86150_ECG			= 1 << (3 + (8*1));
 			public static final int MAX86916_PPG_BLUE		= 1 << (2 + (8*1));
 			public static final int VBATT					= 1 << (1 + (8*1));
+
+			// Second-generation hardware (SR68-9/10, SR61-5/6): LSM6DSV accel/gyro +
+			// LIS2MDL mag. Distinct host-internal bits; accel/gyro enables are derived
+			// from the payload header ACCEL2/GYRO bits and mag from GEN_CFG_3 (see
+			// VerisenseDevice.configBytesParse second-generation branch).
+			public static final int LSM6DSV_ACCEL			= 1 << (4 + (8*0));
+			public static final int LSM6DSV_GYRO			= 1 << (3 + (8*0));
+			public static final int LSM6DSV_MAG				= 1 << (2 + (8*0));
 		}
 		
 		public class DerivedSensorsBitMask {
@@ -2667,6 +2675,10 @@ public class Configuration {
 			public static final int MAX86916_PPG_BLUE 		= 2012;
 			public static final int VBATT			 		= 2013;
 			public static final int GSR				 		= 2014;
+			// Second-generation hardware (SR68-9/10, SR61-5/6)
+			public static final int LSM6DSV_ACCEL			= 2015;
+			public static final int LSM6DSV_GYRO			= 2016;
+			public static final int LSM6DSV_MAG				= 2017;
 		}
 		
 		public enum LABEL_SENSOR_TILE{
@@ -2711,6 +2723,12 @@ public class Configuration {
 			
 			public static final List<ShimmerVerObject> listOfCompatibleVersionInfoGsr = Arrays.asList(
 					svoVerisenseGsrPlus, svoVerisensePulsePlus);
+
+			// Second-generation IMU: LSM6DSV (accel/gyro) + LIS2MDL (mag), SR68-9/10.
+			// TODO refine to HW minor >= 9 once compat supports minor gating; matching all
+			// Pulse+ is acceptable for now as gen-1 Pulse+ carries no LSM6DSV.
+			public static final List<ShimmerVerObject> listOfCompatibleVersionInfoLSM6DSV = Arrays.asList(
+					svoVerisensePulsePlus);
 		}
 
 	}

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/driver/Configuration.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/driver/Configuration.java
@@ -2721,14 +2721,17 @@ public class Configuration {
 			public static final List<ShimmerVerObject> listOfCompatibleVersionInfoVbatt = Arrays.asList(
 					svoVerisenseDevBrd, svoVerisenseImu, svoVerisensePpg0, svoVerisensePpg1, svoVerisenseGsrPlus, svoVerisensePulsePlus);
 			
+			// SR61 (Verisense IMU) carries GSR from minor rev 5 (second-generation); the
+			// runtime minor-rev gating is in VerisenseDevice.doesHwSupportGsr() which
+			// mirrors the firmware's ShimBrd_isGsrSupportedForHwVersion.
 			public static final List<ShimmerVerObject> listOfCompatibleVersionInfoGsr = Arrays.asList(
-					svoVerisenseGsrPlus, svoVerisensePulsePlus);
+					svoVerisenseGsrPlus, svoVerisensePulsePlus, svoVerisenseImu);
 
-			// Second-generation IMU: LSM6DSV (accel/gyro) + LIS2MDL (mag), SR68-9/10.
-			// TODO refine to HW minor >= 9 once compat supports minor gating; matching all
-			// Pulse+ is acceptable for now as gen-1 Pulse+ carries no LSM6DSV.
+			// Second-generation IMU: LSM6DSV (accel/gyro) + LIS2MDL (mag), SR68-9/10 and
+			// SR61-5/6. TODO refine to HW minor gating once compat supports it; the
+			// runtime isPayloadDesignV13orAbove() gate protects gen-1 units meanwhile.
 			public static final List<ShimmerVerObject> listOfCompatibleVersionInfoLSM6DSV = Arrays.asList(
-					svoVerisensePulsePlus);
+					svoVerisensePulsePlus, svoVerisenseImu);
 		}
 
 	}

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/driver/Configuration.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/driver/Configuration.java
@@ -2647,6 +2647,8 @@ public class Configuration {
 			public static final int LSM6DSV_ACCEL			= 1 << (4 + (8*0));
 			public static final int LSM6DSV_GYRO			= 1 << (3 + (8*0));
 			public static final int LSM6DSV_MAG				= 1 << (2 + (8*0));
+			/** VD6283TX45 ambient light (second-generation HW); enable is GEN_CFG_3 bit 3. */
+			public static final int VD6283					= 1 << (1 + (8*0));
 		}
 		
 		public class DerivedSensorsBitMask {
@@ -2682,6 +2684,7 @@ public class Configuration {
 			public static final int LSM6DSV_ACCEL			= 2015;
 			public static final int LSM6DSV_GYRO			= 2016;
 			public static final int LSM6DSV_MAG				= 2017;
+			public static final int VD6283					= 2018;
 		}
 		
 		public enum LABEL_SENSOR_TILE{

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/driver/Configuration.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/driver/Configuration.java
@@ -2649,6 +2649,8 @@ public class Configuration {
 			public static final int LSM6DSV_MAG				= 1 << (2 + (8*0));
 			/** VD6283TX45 ambient light (second-generation HW); enable is GEN_CFG_3 bit 3. */
 			public static final int VD6283					= 1 << (1 + (8*0));
+			/** MLX90632 skin temperature (second-generation HW); enable is GEN_CFG_3 bit 4. */
+			public static final int MLX90632				= 1 << (0 + (8*0));
 		}
 		
 		public class DerivedSensorsBitMask {
@@ -2685,6 +2687,7 @@ public class Configuration {
 			public static final int LSM6DSV_GYRO			= 2016;
 			public static final int LSM6DSV_MAG				= 2017;
 			public static final int VD6283					= 2018;
+			public static final int MLX90632				= 2019;
 		}
 		
 		public enum LABEL_SENSOR_TILE{

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/driver/Configuration.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/driver/Configuration.java
@@ -2660,6 +2660,9 @@ public class Configuration {
 			public final static int GYRO_ON_THE_FLY_CAL		= (1 << 7);
 			public final static int ORIENTATION_6DOF_QUAT 	= (1 << 8);
 			public final static int ORIENTATION_6DOF_EULER 	= (1 << 9);
+			/** Second-generation IMU (SR61-5/6, SR68-9/10). Bit assignment must stay
+			 * unique against any consumer that persists these derived-sensor bits. */
+			public final static int NON_WEAR_DETECTION_LSM6DSV	= (1 << 10);
 		}
 
 		public class SENSOR_ID {

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/sensors/AbstractSensor.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/sensors/AbstractSensor.java
@@ -68,6 +68,7 @@ public abstract class AbstractSensor implements Serializable{
 		LIS3MDL("LIS3MDL"), //to be changed
 		LIS2MDL("LIS2MDL"),
 		LSM6DSV("LSM6DSV"),
+		VD6283("VD6283"),
 		BMP390("BMP390");
 		
 	    private final String text;

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/sensors/AbstractSensor.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/sensors/AbstractSensor.java
@@ -69,6 +69,7 @@ public abstract class AbstractSensor implements Serializable{
 		LIS2MDL("LIS2MDL"),
 		LSM6DSV("LSM6DSV"),
 		VD6283("VD6283"),
+		MLX90632("MLX90632"),
 		BMP390("BMP390");
 		
 	    private final String text;

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/sensors/SensorBattVoltage.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/sensors/SensorBattVoltage.java
@@ -68,6 +68,10 @@ public class SensorBattVoltage extends AbstractSensor{
 	
 	// The battery voltage is divided by half before entering the Microcontroller's ADC.  The value is not quite equal to 2 due to the components used in the circuit.
 	public static final double BATTERY_VOLTAGE_DIVIDER_RATIO = 1.988;
+
+	// Second-generation Verisense hardware (SR61-5/6, SR68-9/10) battery-sense divider.
+	// Matches the firmware's conversion in hal_asm_battery.c (measureBatteryVoltage).
+	public static final double BATTERY_VOLTAGE_DIVIDER_RATIO_GEN2 = 2.469;
 	
 	//--------- Sensor specific variables end --------------
 	

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/VerisenseDevice.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/VerisenseDevice.java
@@ -1295,7 +1295,11 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 	public boolean doesHwSupportGsr() {
 		int hwId = getHardwareVersion();
 		int hwRev = getExpansionBoardRev();
-		return (hwId==HW_ID.VERISENSE_GSR_PLUS || (hwId==HW_ID.VERISENSE_PULSE_PLUS && hwRev >=5));
+		// Mirrors the firmware's ShimBrd_isGsrSupportedForHwVersion (shimmer_boards.c):
+		// SR62 (any), SR68 minor >= 5, SR61 minor >= 5 (second-generation IMU carries GSR).
+		return (hwId==HW_ID.VERISENSE_GSR_PLUS
+				|| (hwId==HW_ID.VERISENSE_PULSE_PLUS && hwRev >=5)
+				|| (hwId==HW_ID.VERISENSE_IMU && hwRev >=5));
 	}
 
 	public CalibDetailsKinematic getCurrentCalibDetails(int sensorId) {

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/VerisenseDevice.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/VerisenseDevice.java
@@ -66,6 +66,7 @@ import com.shimmerresearch.verisense.sensors.SensorGSRVerisense;
 import com.shimmerresearch.verisense.sensors.SensorLIS2DW12;
 import com.shimmerresearch.verisense.sensors.SensorLSM6DS3;
 import com.shimmerresearch.verisense.sensors.SensorLSM6DSV;
+import com.shimmerresearch.verisense.sensors.SensorVD6283;
 import com.shimmerresearch.verisense.sensors.SensorMAX86150;
 import com.shimmerresearch.verisense.sensors.SensorMAX86916;
 import com.shimmerresearch.verisense.sensors.SensorMAX86XXX;
@@ -587,6 +588,7 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 			if((gen2Cfg0 & (1<<5))!=0) { enabledSensors |= Configuration.Verisense.SensorBitmap.LSM6DSV_GYRO; }
 			int gen2GenCfg3 = configBytes[PAYLOAD_CONFIG_BYTE_INDEX.GEN_CFG_3] & 0xFF;
 			if((gen2GenCfg3 & (1<<2))!=0) { enabledSensors |= Configuration.Verisense.SensorBitmap.LSM6DSV_MAG; }
+			if((gen2GenCfg3 & (1<<3))!=0) { enabledSensors |= Configuration.Verisense.SensorBitmap.VD6283; }
 		}
 		setEnabledAndDerivedSensorsAndUpdateMaps(enabledSensors, mDerivedSensors, commType);
 		
@@ -1056,6 +1058,32 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 			sb.append(SENSOR_CONFIG_STRINGS.RESOLUTION);
 			sb.append("16-bit");
 			sb.append("}");
+		} else if(sensorClassKey==AbstractSensor.SENSORS.VD6283
+				&& isSensorEnabled(Configuration.Verisense.SENSOR_ID.VD6283)) {
+			// Second-generation ambient light. The configured sample rate isn't stored
+			// in the payload header, so only the calculated (achieved) rate is reported.
+			SensorVD6283 sensorVd6283 = getSensorVD6283();
+
+			sb.append(sensorClassKey.toString());
+			sb.append(" {Sampling Rate [");
+			sb.append(SENSOR_CONFIG_STRINGS.SAMPLING_RATE_CALCULATED);
+			if(!Double.isNaN(calculatedSamplingRate)) {
+				sb.append(UtilVerisenseDriver.formatDoubleToNdecimalPlaces(calculatedSamplingRate, 3));
+				sb.append(" ");
+				sb.append(CHANNEL_UNITS.FREQUENCY);
+			} else {
+				sb.append(UtilVerisenseDriver.UNAVAILABLE);
+			}
+			sb.append("]; Gain = ");
+			sb.append(UtilVerisenseDriver.formatDoubleToNdecimalPlaces(sensorVd6283.getGain(), 2));
+			sb.append("x; Exposure = ");
+			sb.append(UtilVerisenseDriver.formatDoubleToNdecimalPlaces(sensorVd6283.getExposureUs()/1000.0, 1));
+			sb.append(" ms; Slot1 = ");
+			sb.append(sensorVd6283.isDarkChannelEnabled() ? "Dark" : "Visible");
+			sb.append("; ");
+			sb.append(SENSOR_CONFIG_STRINGS.RESOLUTION);
+			sb.append("24-bit");
+			sb.append("}");
 		} else if(LIST_OF_PPG_SENSORS.contains(sensorClassKey) && isHwPpgAndAnyMaxChEnabled()) {
 			AbstractSensor abstractSensor = getAbstractSensorPpg();
 			if(abstractSensor!=null) {
@@ -1360,6 +1388,8 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 		if(isPayloadDesignV13orAbove()) {
 			// Second-generation IMU (LSM6DSV accel/gyro + LIS2MDL mag via sensor hub)
 			addSensorClass(SENSORS.LSM6DSV, new SensorLSM6DSV(this));
+			// Second-generation ambient light
+			addSensorClass(SENSORS.VD6283, new SensorVD6283(this));
 		} else if(doesHwSupportLsm6ds3()) {
 			addSensorClass(SENSORS.LSM6DS3, new SensorLSM6DS3(this));
 		}
@@ -1573,6 +1603,9 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 			case LSM6DSV:
 				listOfSensorIds.add(SENSORS.LSM6DSV);
 				break;
+			case LIGHT:
+				listOfSensorIds.add(SENSORS.VD6283);
+				break;
 			case PPG:
 				SENSORS sensorClassKey = getPpgSensorClassKey();
 				if(sensorClassKey!=null) {
@@ -1593,6 +1626,11 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 		switch(sensorClassKey) {
 			case LIS2DW12:
 				dataBlockSize = SensorLIS2DW12.FIFO_SIZE_IN_CHIP;
+				break;
+			case VD6283:
+				// Fixed-size block: the firmware only emits FULL blocks of
+				// NUM_LIGHT_SAMPLES_PER_BLOCK samples (partials are discarded on stop).
+				dataBlockSize = SensorVD6283.BLOCK_DATA_BYTES;
 				break;
 			case LSM6DS3:
 				AbstractSensor abstractSensor = getSensorClass(SENSORS.LSM6DS3);
@@ -1886,7 +1924,7 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 		// without a getSensorKeysForDatablockId()/calculateFifoBlockSize() handler
 		// would corrupt the parse, so they are rejected with the informative
 		// exception below until their decoders are implemented.
-		if(sensorId>0 && sensorId<=DATABLOCK_SENSOR_ID.LSM6DSV.ordinal()) {
+		if(sensorId>0 && sensorId<=DATABLOCK_SENSOR_ID.LIGHT.ordinal()) {
 			DATABLOCK_SENSOR_ID datablockSensorId = payloadSensorIdValues[sensorId];
 			
 			List<SENSORS> listOfSensorClassKeys = getOrCreateListOfSensorClassKeysForDataBlockId(datablockSensorId);
@@ -2324,6 +2362,14 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 		AbstractSensor abstractSensor = getSensorClass(SENSORS.LSM6DSV);
 		if(abstractSensor!=null && abstractSensor instanceof SensorLSM6DSV) {
 			return (SensorLSM6DSV) abstractSensor;
+		}
+		return null;
+	}
+
+	public SensorVD6283 getSensorVD6283() {
+		AbstractSensor abstractSensor = getSensorClass(SENSORS.VD6283);
+		if(abstractSensor!=null && abstractSensor instanceof SensorVD6283) {
+			return (SensorVD6283) abstractSensor;
 		}
 		return null;
 	}

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/VerisenseDevice.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/VerisenseDevice.java
@@ -805,6 +805,8 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 			return SENSORS.LIS2DW12;
 		} else if(isSensorEnabled(Configuration.Verisense.SENSOR_ID.LSM6DS3_ACCEL)) {
 			return SENSORS.LSM6DS3;
+		} else if(isSensorEnabled(Configuration.Verisense.SENSOR_ID.LSM6DSV_ACCEL)) {
+			return SENSORS.LSM6DSV;
 		}
 		return null;
 	}
@@ -1032,9 +1034,20 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 			sb.append("; Mag ");
 			sb.append(SENSOR_CONFIG_STRINGS.RATE);
 			if(isSensorEnabled(Configuration.Verisense.SENSOR_ID.LSM6DSV_MAG)) {
+				// Labelled "Configured" because the sensor hub reads the LIS2MDL once per
+				// accel/gyro sample, so the EFFECTIVE mag rate is capped at the IMU ODR.
+				sb.append(SENSOR_CONFIG_STRINGS.SAMPLING_RATE_CONFIGURED);
 				sb.append(sensorLsm6dsv.getMagRateFreq());
 				sb.append(" ");
 				sb.append(CHANNEL_UNITS.FREQUENCY);
+				double imuOdrHz = sensorLsm6dsv.getRateFreq();
+				if(imuOdrHz>0 && sensorLsm6dsv.getMagRateFreq()>imuOdrHz) {
+					sb.append(" (capped to ");
+					sb.append(imuOdrHz);
+					sb.append(" ");
+					sb.append(CHANNEL_UNITS.FREQUENCY);
+					sb.append(" by the IMU rate)");
+				}
 			} else {
 				sb.append("Off");
 			}
@@ -1237,14 +1250,15 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 	//TODO set derived algorithm enabled bit like as done for PPG rather then checking
 	public boolean isAnAccelEnabled() {
 		if(isSensorEnabled(Configuration.Verisense.SENSOR_ID.LIS2DW12_ACCEL)
-				|| isSensorEnabled(Configuration.Verisense.SENSOR_ID.LSM6DS3_ACCEL)) {
+				|| isSensorEnabled(Configuration.Verisense.SENSOR_ID.LSM6DS3_ACCEL)
+				|| isSensorEnabled(Configuration.Verisense.SENSOR_ID.LSM6DSV_ACCEL)) {
 			return true;
 		}
 		return false;
 	}
 
 	public static boolean isSensorKeyAnAccel(SENSORS sensorClassKey) {
-		if(sensorClassKey==SENSORS.LIS2DW12 || sensorClassKey==SENSORS.LSM6DS3) {
+		if(sensorClassKey==SENSORS.LIS2DW12 || sensorClassKey==SENSORS.LSM6DS3 || sensorClassKey==SENSORS.LSM6DSV) {
 			return true;
 		}
 		return false;
@@ -1623,6 +1637,11 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 			default:
 				break;
 		}
+		if(dataBlockSize==Integer.MIN_VALUE) {
+			// Fail loudly rather than returning a sentinel that silently corrupts the
+			// data-block byte index further down the parse.
+			throw new IllegalStateException("calculateFifoBlockSize: no FIFO block size defined for sensor class " + sensorClassKey);
+		}
 		return dataBlockSize;
 	}
 
@@ -1861,8 +1880,13 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 		
 		DataBlockDetails dataBlockDetails = null;
 		DATABLOCK_SENSOR_ID[] payloadSensorIdValues = DATABLOCK_SENSOR_ID.values();
-		// -1 because PPG_MAX86150 has been temporarily added to PAYLOAD_SENSOR_ID 
-		if(sensorId>0 && sensorId<payloadSensorIdValues.length-1) {
+		// Only IDs with a parse implementation are accepted. The enum intentionally
+		// declares the remaining second-generation block IDs (LIGHT, ALGO_HUB,
+		// SKIN_TEMP, FLICKER) ahead of their parser support - accepting them here
+		// without a getSensorKeysForDatablockId()/calculateFifoBlockSize() handler
+		// would corrupt the parse, so they are rejected with the informative
+		// exception below until their decoders are implemented.
+		if(sensorId>0 && sensorId<=DATABLOCK_SENSOR_ID.LSM6DSV.ordinal()) {
 			DATABLOCK_SENSOR_ID datablockSensorId = payloadSensorIdValues[sensorId];
 			
 			List<SENSORS> listOfSensorClassKeys = getOrCreateListOfSensorClassKeysForDataBlockId(datablockSensorId);

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/VerisenseDevice.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/VerisenseDevice.java
@@ -66,6 +66,7 @@ import com.shimmerresearch.verisense.sensors.SensorGSRVerisense;
 import com.shimmerresearch.verisense.sensors.SensorLIS2DW12;
 import com.shimmerresearch.verisense.sensors.SensorLSM6DS3;
 import com.shimmerresearch.verisense.sensors.SensorLSM6DSV;
+import com.shimmerresearch.verisense.sensors.SensorMLX90632;
 import com.shimmerresearch.verisense.sensors.SensorVD6283;
 import com.shimmerresearch.verisense.sensors.SensorMAX86150;
 import com.shimmerresearch.verisense.sensors.SensorMAX86916;
@@ -589,6 +590,7 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 			int gen2GenCfg3 = configBytes[PAYLOAD_CONFIG_BYTE_INDEX.GEN_CFG_3] & 0xFF;
 			if((gen2GenCfg3 & (1<<2))!=0) { enabledSensors |= Configuration.Verisense.SensorBitmap.LSM6DSV_MAG; }
 			if((gen2GenCfg3 & (1<<3))!=0) { enabledSensors |= Configuration.Verisense.SensorBitmap.VD6283; }
+			if((gen2GenCfg3 & (1<<4))!=0) { enabledSensors |= Configuration.Verisense.SensorBitmap.MLX90632; }
 		}
 		setEnabledAndDerivedSensorsAndUpdateMaps(enabledSensors, mDerivedSensors, commType);
 		
@@ -1084,6 +1086,23 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 			sb.append(SENSOR_CONFIG_STRINGS.RESOLUTION);
 			sb.append("24-bit");
 			sb.append("}");
+		} else if(sensorClassKey==AbstractSensor.SENSORS.MLX90632
+				&& isSensorEnabled(Configuration.Verisense.SENSOR_ID.MLX90632)) {
+			// Second-generation skin temperature.
+			SensorMLX90632 sensorMlx90632 = getSensorMLX90632();
+
+			sb.append(generateCalcSamplingRateConfigStr(sensorClassKey, sensorMlx90632.getRateFreq(), calculatedSamplingRate));
+
+			sb.append("Refresh = ");
+			sb.append(UtilVerisenseDriver.formatDoubleToNdecimalPlaces(sensorMlx90632.getRefreshHz(), 1));
+			sb.append(" ");
+			sb.append(CHANNEL_UNITS.FREQUENCY);
+			sb.append("; Mode = ");
+			sb.append(sensorMlx90632.getMeasTypeString());
+			sb.append("; ");
+			sb.append(SENSOR_CONFIG_STRINGS.RESOLUTION);
+			sb.append("16-bit");
+			sb.append("}");
 		} else if(LIST_OF_PPG_SENSORS.contains(sensorClassKey) && isHwPpgAndAnyMaxChEnabled()) {
 			AbstractSensor abstractSensor = getAbstractSensorPpg();
 			if(abstractSensor!=null) {
@@ -1388,8 +1407,9 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 		if(isPayloadDesignV13orAbove()) {
 			// Second-generation IMU (LSM6DSV accel/gyro + LIS2MDL mag via sensor hub)
 			addSensorClass(SENSORS.LSM6DSV, new SensorLSM6DSV(this));
-			// Second-generation ambient light
+			// Second-generation ambient light + skin temperature
 			addSensorClass(SENSORS.VD6283, new SensorVD6283(this));
+			addSensorClass(SENSORS.MLX90632, new SensorMLX90632(this));
 		} else if(doesHwSupportLsm6ds3()) {
 			addSensorClass(SENSORS.LSM6DS3, new SensorLSM6DS3(this));
 		}
@@ -1606,6 +1626,9 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 			case LIGHT:
 				listOfSensorIds.add(SENSORS.VD6283);
 				break;
+			case SKIN_TEMP:
+				listOfSensorIds.add(SENSORS.MLX90632);
+				break;
 			case PPG:
 				SENSORS sensorClassKey = getPpgSensorClassKey();
 				if(sensorClassKey!=null) {
@@ -1631,6 +1654,10 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 				// Fixed-size block: the firmware only emits FULL blocks of
 				// NUM_LIGHT_SAMPLES_PER_BLOCK samples (partials are discarded on stop).
 				dataBlockSize = SensorVD6283.BLOCK_DATA_BYTES;
+				break;
+			case MLX90632:
+				// Fixed-size block: full blocks of NUM_TEMP_SAMPLES_PER_BLOCK samples only.
+				dataBlockSize = SensorMLX90632.BLOCK_DATA_BYTES;
 				break;
 			case LSM6DS3:
 				AbstractSensor abstractSensor = getSensorClass(SENSORS.LSM6DS3);
@@ -1924,7 +1951,9 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 		// without a getSensorKeysForDatablockId()/calculateFifoBlockSize() handler
 		// would corrupt the parse, so they are rejected with the informative
 		// exception below until their decoders are implemented.
-		if(sensorId>0 && sensorId<=DATABLOCK_SENSOR_ID.LIGHT.ordinal()) {
+		// Parse-supported block ids: everything up to LIGHT (7), plus SKIN_TEMP (9).
+		// ALGO_HUB (8) and FLICKER (10) still fail loudly below until their decoders land.
+		if(sensorId>0 && (sensorId<=DATABLOCK_SENSOR_ID.LIGHT.ordinal() || sensorId==DATABLOCK_SENSOR_ID.SKIN_TEMP.ordinal())) {
 			DATABLOCK_SENSOR_ID datablockSensorId = payloadSensorIdValues[sensorId];
 			
 			List<SENSORS> listOfSensorClassKeys = getOrCreateListOfSensorClassKeysForDataBlockId(datablockSensorId);
@@ -2370,6 +2399,14 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 		AbstractSensor abstractSensor = getSensorClass(SENSORS.VD6283);
 		if(abstractSensor!=null && abstractSensor instanceof SensorVD6283) {
 			return (SensorVD6283) abstractSensor;
+		}
+		return null;
+	}
+
+	public SensorMLX90632 getSensorMLX90632() {
+		AbstractSensor abstractSensor = getSensorClass(SENSORS.MLX90632);
+		if(abstractSensor!=null && abstractSensor instanceof SensorMLX90632) {
+			return (SensorMLX90632) abstractSensor;
 		}
 		return null;
 	}

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/VerisenseDevice.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/VerisenseDevice.java
@@ -2027,9 +2027,20 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 		int numEntries = (byteBuffer[currentByteIndex] & 0xFF) | ((byteBuffer[currentByteIndex+1] & 0xFF) << 8);
 		int entriesStart = currentByteIndex + 2;
 
+		boolean accelEn = isSensorEnabled(Configuration.Verisense.SENSOR_ID.LSM6DSV_ACCEL);
+		boolean gyroEn = isSensorEnabled(Configuration.Verisense.SENSOR_ID.LSM6DSV_GYRO);
+		boolean magEn = isSensorEnabled(Configuration.Verisense.SENSOR_ID.LSM6DSV_MAG);
+
+		// The aligned (accel/gyro) reference stream drives per-sample timing and, for
+		// midday/midnight-split blocks, defines each half's share of the FIFO. Each mag
+		// entry records how many reference entries preceded it in the FIFO so it can be
+		// assigned to the correct half by arrival order.
+		int refTag = accelEn ? LSM6DSV_TAG_ACCEL : LSM6DSV_TAG_GYRO;
 		List<byte[]> accelSamples = new ArrayList<byte[]>();
 		List<byte[]> gyroSamples = new ArrayList<byte[]>();
 		List<byte[]> magSamples = new ArrayList<byte[]>();
+		List<Integer> magAlignedPos = new ArrayList<Integer>();
+		int alignedSeen = 0;
 		for(int k=0;k<numEntries;k++) {
 			int eo = entriesStart + k*7;
 			int tag = ((byteBuffer[eo] & 0xFF) >> 3) & 0x1F;
@@ -2038,17 +2049,42 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 				System.arraycopy(byteBuffer, eo+1, xyz, 0, 6);
 				if(tag==LSM6DSV_TAG_ACCEL) { accelSamples.add(xyz); }
 				else if(tag==LSM6DSV_TAG_GYRO) { gyroSamples.add(xyz); }
-				else { magSamples.add(xyz); }
+				else {
+					magSamples.add(xyz);
+					magAlignedPos.add(alignedSeen);
+				}
+				if(tag==refTag) { alignedSeen++; }
 			}
 			// tag 0x04 (timestamp) intentionally skipped
 		}
 
-		boolean accelEn = isSensorEnabled(Configuration.Verisense.SENSOR_ID.LSM6DSV_ACCEL);
-		boolean gyroEn = isSensorEnabled(Configuration.Verisense.SENSOR_ID.LSM6DSV_GYRO);
-		boolean magEn = isSensorEnabled(Configuration.Verisense.SENSOR_ID.LSM6DSV_MAG);
+		int alignedCountFull = accelEn ? accelSamples.size() : (gyroEn ? gyroSamples.size() : 0);
 
-		int alignedCount = accelEn ? accelSamples.size() : (gyroEn ? gyroSamples.size() : 0);
-		int magCount = magEn ? magSamples.size() : 0;
+		// Midday/midnight-split support: both halves of a split block are handed the SAME
+		// raw block bytes (see the byte-offset walk in PayloadContentsDetailsV8orAbove);
+		// each half parses only its own aligned-sample range. The metadata-time split set
+		// each part's sampleCount in the aligned-sample domain.
+		int alignedFrom = 0;
+		int alignedTo = alignedCountFull;
+		if(dataBlockDetails.isFirstPartOfSplitDataBlock()) {
+			alignedTo = Math.min(dataBlockDetails.getSampleCount(), alignedCountFull);
+		} else if(dataBlockDetails.isSecondPartOfSplitDataBlock()) {
+			alignedFrom = Math.max(0, alignedCountFull - dataBlockDetails.getSampleCount());
+		}
+		int alignedCount = alignedTo - alignedFrom;
+
+		// Mag entries are assigned to a split half by FIFO arrival order relative to the
+		// aligned boundary: an entry that arrived before the first aligned sample of the
+		// second half belongs to the first half.
+		List<byte[]> magSamplesPart = new ArrayList<byte[]>();
+		if(magEn) {
+			for(int i=0;i<magSamples.size();i++) {
+				int pos = magAlignedPos.get(i);
+				boolean inPart = dataBlockDetails.isSecondPartOfSplitDataBlock() ? (pos > alignedFrom) : (pos <= alignedTo);
+				if(inPart) { magSamplesPart.add(magSamples.get(i)); }
+			}
+		}
+		int magCount = magSamplesPart.size();
 		dataBlockDetails.setupOjcArray(alignedCount + magCount);
 
 		// SensorDetails for per-stream enable toggling. Accel + gyro are synchronous (same
@@ -2078,7 +2114,7 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 				if(magDet!=null) { magDet.setIsEnabled(false); }
 				int alignedPacketSize = getExpectedDataPacketSize(SENSORS.LSM6DSV);
 				double timeMsCurrentSample = startTimeMs;
-				for(int i=0;i<alignedCount;i++) {
+				for(int i=alignedFrom;i<alignedTo;i++) {
 					byte[] byteBuf = new byte[alignedPacketSize];
 					int offset = 0;
 					if(accelEn && i<accelSamples.size()) { System.arraycopy(accelSamples.get(i), 0, byteBuf, offset, 6); }
@@ -2092,7 +2128,7 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 				}
 			}
 
-			// Pass 2: mag stream (only mag enabled), spread evenly across the block duration
+			// Pass 2: mag stream (only mag enabled), spread evenly across this part's duration
 			if(magCount>0) {
 				if(accelDet!=null) { accelDet.setIsEnabled(false); }
 				if(gyroDet!=null) { gyroDet.setIsEnabled(false); }
@@ -2112,7 +2148,7 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 				double magTimeMs = startTimeMs;
 				for(int i=0;i<magCount;i++) {
 					byte[] byteBuf = new byte[magPacketSize];
-					System.arraycopy(magSamples.get(i), 0, byteBuf, 0, 6);
+					System.arraycopy(magSamplesPart.get(i), 0, byteBuf, 0, 6);
 					ObjectCluster ojcCurrent = buildMsgForSensorList(byteBuf, commType, dataBlockDetails.listOfSensorClassKeys, magTimeMs);
 					dataHandler(ojcCurrent);
 					dataBlockDetails.setOjcArrayAtIndex(ojcIndex++, ojcCurrent);

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/VerisenseDevice.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/VerisenseDevice.java
@@ -65,6 +65,7 @@ import com.shimmerresearch.verisense.sensors.SensorBattVoltageVerisense;
 import com.shimmerresearch.verisense.sensors.SensorGSRVerisense;
 import com.shimmerresearch.verisense.sensors.SensorLIS2DW12;
 import com.shimmerresearch.verisense.sensors.SensorLSM6DS3;
+import com.shimmerresearch.verisense.sensors.SensorLSM6DSV;
 import com.shimmerresearch.verisense.sensors.SensorMAX86150;
 import com.shimmerresearch.verisense.sensors.SensorMAX86916;
 import com.shimmerresearch.verisense.sensors.SensorMAX86XXX;
@@ -236,6 +237,22 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 		public static final ShimmerVerObject CCF21_010_2 = new ShimmerVerObject(FW_ID.UNKNOWN, 1, 2, 87);
 		/** GSR support with ADC sampling rate byte added to header */
 		public static final ShimmerVerObject CCF21_010_3 = new ShimmerVerObject(FW_ID.UNKNOWN, 1, 2, 88);
+		/**
+		 * Second-generation hardware support (SR68-9/10, SR61-5/6). The firmware
+		 * refers to this as "payload design v9": it writes a 32-byte config header
+		 * (bytes 4..35, vs 25 bytes / bytes 4..28 previously; bytes 34..35 are the
+		 * calibration-blob CRC) and introduces the
+		 * LSM6DSV/ambient-light/algorithm-hub/skin-temperature data blocks.
+		 * <p>
+		 * In this driver's own (separate) payload-design numbering this is the next
+		 * step after V12 ({@link #CCF21_010_3}), exposed as
+		 * {@link VerisenseDevice#isPayloadDesignV13orAbove()}. The two "v9" numbers
+		 * are NOT the same axis - see that method's Javadoc.
+		 * <p>
+		 * Confirmed against a real SR68-9 device: it reports FW v2.00.004 (the doc's
+		 * "1.04.024" is stale). The 36-byte total header = 4 (index+length) + 32 config.
+		 */
+		public static final ShimmerVerObject CCF_GEN2 = new ShimmerVerObject(FW_ID.UNKNOWN, 2, 0, 4);
 	}
 
 	public static class FW_SPECIAL_VERSIONS {
@@ -558,6 +575,16 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 			ppgRecordingIntervalMinutes = (int) AbstractPayload.parseByteArrayAtIndex(configBytes, OP_CONFIG_BYTE_INDEX.PPG_REC_INT_MINS_LSB, CHANNEL_DATA_TYPE.UINT16);
 		}
 
+		if(commType==COMMUNICATION_TYPE.SD && isPayloadDesignV13orAbove()) {
+			// Second-generation: ACCEL2/GYRO enable bits (PAYLOAD_CONFIG0 bits 6/5) map to the
+			// LSM6DSV (not LSM6DS3); LIS2MDL mag enable is in GEN_CFG_3 (abs byte 29) bit 2.
+			enabledSensors = 0;
+			int gen2Cfg0 = configBytes[PAYLOAD_CONFIG_BYTE_INDEX.PAYLOAD_CONFIG0] & 0xFF;
+			if((gen2Cfg0 & (1<<6))!=0) { enabledSensors |= Configuration.Verisense.SensorBitmap.LSM6DSV_ACCEL; }
+			if((gen2Cfg0 & (1<<5))!=0) { enabledSensors |= Configuration.Verisense.SensorBitmap.LSM6DSV_GYRO; }
+			int gen2GenCfg3 = configBytes[PAYLOAD_CONFIG_BYTE_INDEX.GEN_CFG_3] & 0xFF;
+			if((gen2GenCfg3 & (1<<2))!=0) { enabledSensors |= Configuration.Verisense.SensorBitmap.LSM6DSV_MAG; }
+		}
 		setEnabledAndDerivedSensorsAndUpdateMaps(enabledSensors, mDerivedSensors, commType);
 		
 		for(AbstractSensor abstractSensor:mMapOfSensorClasses.values()) {
@@ -681,6 +708,44 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 	}
 
 	/**
+	 * Second-generation payload design (firmware "v9" / 30-byte config header).
+	 * @see PayloadContentsDetails#isPayloadDesignV13orAbove(ShimmerVerObject)
+	 */
+	public boolean isPayloadDesignV13orAbove() {
+		return PayloadContentsDetails.isPayloadDesignV13orAbove(getShimmerVerObject());
+	}
+
+	/**
+	 * Whether a given Verisense hardware revision is second-generation
+	 * (SR68-9/10, SR61-5/6). Mirrors the TypeScript SDK
+	 * (shimmer-web-sdk: hardwareModels.ts {@code isVerisenseSecondGenerationHardware})
+	 * and the firmware Model IC matrix
+	 * (verisense-firmware/docs/VERISENSE_MODEL_IC_MATRIX.md):
+	 * <ul>
+	 *   <li>SR61, minor &ge; 5</li>
+	 *   <li>SR68, minor &ge; 9</li>
+	 *   <li>any future major revision above SR68 (68)</li>
+	 * </ul>
+	 * Gen-2 is distinguished by hardware major/minor revision, NOT by a separate
+	 * {@code HW_ID_SR_CODES} value (SR68-9/10 is still the Pulse+ major id 68).
+	 *
+	 * @param hwMajor REV_HW_MAJOR from the payload header / production config
+	 * @param hwMinor REV_HW_MINOR from the payload header / production config
+	 */
+	public static boolean isSecondGenerationHardware(int hwMajor, int hwMinor) {
+		if(hwMajor > HW_ID.VERISENSE_PULSE_PLUS) {
+			return true;
+		}
+		if(hwMajor == HW_ID.VERISENSE_IMU && hwMinor >= 5) {
+			return true;
+		}
+		if(hwMajor == HW_ID.VERISENSE_PULSE_PLUS && hwMinor >= 9) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
 	 * @return
 	 * @see PayloadContentsDetails.isCsvHeaderDesignAzMarkingPoint()
 	 */
@@ -704,6 +769,8 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 			return getSamplingRateForSensor(SENSORS.LIS2DW12);
 		} else if(isEitherLsm6ds3ChannelEnabled()) {
 			return getSamplingRateForSensor(SENSORS.LSM6DS3);
+		} else if(isAnyLsm6dsvChannelEnabled()) {
+			return getSamplingRateForSensor(SENSORS.LSM6DSV);
 		} else if(isHwPpgAndAnyMaxChEnabled()) {
 			return getSamplingRateForSensor(getPpgSensorClassKey());
 		} else if(isSensorEnabled(Configuration.Verisense.SENSOR_ID.VBATT)) {
@@ -942,6 +1009,36 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 				sb.append("16-bit");
 				sb.append("}");
 			}
+		} else if((sensorClassKey==AbstractSensor.SENSORS.LSM6DSV)
+				&& isAnyLsm6dsvChannelEnabled()) {
+			// Second-generation IMU (LSM6DSV accel/gyro + LIS2MDL mag). Gen-2 always uses the
+			// new (non-AZ-marking-point) CSV header design.
+			SensorLSM6DSV sensorLsm6dsv = getSensorLSM6DSV();
+
+			sb.append(generateCalcSamplingRateConfigStr(sensorClassKey, sensorLsm6dsv.getRateFreq(), calculatedSamplingRate));
+
+			sb.append("Accel ");
+			sb.append(SENSOR_CONFIG_STRINGS.RANGE);
+			sb.append(isSensorEnabled(Configuration.Verisense.SENSOR_ID.LSM6DSV_ACCEL) ? sensorLsm6dsv.getAccelRangeString() : "Off");
+
+			sb.append("; Gyro ");
+			sb.append(SENSOR_CONFIG_STRINGS.RANGE);
+			sb.append(isSensorEnabled(Configuration.Verisense.SENSOR_ID.LSM6DSV_GYRO) ? sensorLsm6dsv.getGyroRangeString() : "Off");
+
+			sb.append("; Mag ");
+			sb.append(SENSOR_CONFIG_STRINGS.RATE);
+			if(isSensorEnabled(Configuration.Verisense.SENSOR_ID.LSM6DSV_MAG)) {
+				sb.append(sensorLsm6dsv.getMagRateFreq());
+				sb.append(" ");
+				sb.append(CHANNEL_UNITS.FREQUENCY);
+			} else {
+				sb.append("Off");
+			}
+
+			sb.append("; ");
+			sb.append(SENSOR_CONFIG_STRINGS.RESOLUTION);
+			sb.append("16-bit");
+			sb.append("}");
 		} else if(LIST_OF_PPG_SENSORS.contains(sensorClassKey) && isHwPpgAndAnyMaxChEnabled()) {
 			AbstractSensor abstractSensor = getAbstractSensorPpg();
 			if(abstractSensor!=null) {
@@ -1152,6 +1249,12 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 	public boolean isEitherLsm6ds3ChannelEnabled() {
 		return isSensorEnabled(Verisense.SENSOR_ID.LSM6DS3_ACCEL) || isSensorEnabled(Verisense.SENSOR_ID.LSM6DS3_GYRO);
 	}
+
+	public boolean isAnyLsm6dsvChannelEnabled() {
+		return isSensorEnabled(Verisense.SENSOR_ID.LSM6DSV_ACCEL)
+				|| isSensorEnabled(Verisense.SENSOR_ID.LSM6DSV_GYRO)
+				|| isSensorEnabled(Verisense.SENSOR_ID.LSM6DSV_MAG);
+	}
 	
 	public boolean doesHwSupportMax86xxx() {
 		return doesHwSupportMax86xxx(getHardwareVersion());
@@ -1232,7 +1335,10 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 			addSensorClass(SENSORS.Battery, new SensorBattVoltageVerisense(this));
 		}
 
-		if(doesHwSupportLsm6ds3()) {
+		if(isPayloadDesignV13orAbove()) {
+			// Second-generation IMU (LSM6DSV accel/gyro + LIS2MDL mag via sensor hub)
+			addSensorClass(SENSORS.LSM6DSV, new SensorLSM6DSV(this));
+		} else if(doesHwSupportLsm6ds3()) {
 			addSensorClass(SENSORS.LSM6DS3, new SensorLSM6DS3(this));
 		}
 		
@@ -1441,6 +1547,9 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 				break;
 			case GYRO_ACCEL2:
 				listOfSensorIds.add(SENSORS.LSM6DS3);
+				break;
+			case LSM6DSV:
+				listOfSensorIds.add(SENSORS.LSM6DSV);
 				break;
 			case PPG:
 				SENSORS sensorClassKey = getPpgSensorClassKey();
@@ -1755,7 +1864,16 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 					rwcEndTimeTicks, isPayloadDesignV11orAbove());
 
 			SENSORS firstSensorClasskey = dataBlockDetails.listOfSensorClassKeys.get(0);
-			int qtySensorDataBytesInDatablock = calculateFifoBlockSize(firstSensorClasskey);
+			int qtySensorDataBytesInDatablock;
+			int lsm6dsvNumEntries = 0;
+			if(datablockSensorId == DATABLOCK_SENSOR_ID.LSM6DSV) {
+				// Variable-length tagged FIFO: [2-byte NUM_SAMPLES][N x 7-byte entries].
+				int numSamplesIndex = dataBlockStartByteIndexInPayload + BYTE_COUNT.PAYLOAD_CONTENTS_GEN8_SENSOR_ID + BYTE_COUNT.PAYLOAD_CONTENTS_RTC_BYTES_TICKS;
+				lsm6dsvNumEntries = (byteBuffer[numSamplesIndex] & 0xFF) | ((byteBuffer[numSamplesIndex+1] & 0xFF) << 8);
+				qtySensorDataBytesInDatablock = 2 + lsm6dsvNumEntries * 7;
+			} else {
+				qtySensorDataBytesInDatablock = calculateFifoBlockSize(firstSensorClasskey);
+			}
 			int dataPacketSize = 0;
 			for(SENSORS sensorClassKey:dataBlockDetails.getListOfSensorClassKeys()) {
 				dataPacketSize += getExpectedDataPacketSize(sensorClassKey);
@@ -1764,6 +1882,12 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 			double samplingRate = getSamplingRateForSensor(firstSensorClasskey);
 			
 			dataBlockDetails.setMetadata(qtySensorDataBytesInDatablock, dataPacketSize, samplingRate);
+			if(datablockSensorId == DATABLOCK_SENSOR_ID.LSM6DSV) {
+				// sampleCount drives per-sample timing + ojc array sizing; use the aligned
+				// accel (or gyro) stream count, not the raw tagged-entry count.
+				int numSamplesIndex = dataBlockStartByteIndexInPayload + BYTE_COUNT.PAYLOAD_CONTENTS_GEN8_SENSOR_ID + BYTE_COUNT.PAYLOAD_CONTENTS_RTC_BYTES_TICKS;
+				dataBlockDetails.setSampleCount(countLsm6dsvAlignedSamples(byteBuffer, numSamplesIndex + 2, lsm6dsvNumEntries));
+			}
 		} else {
 			IOException e = new IOException("Error parsing Data Block. SensorID=" + UtilShimmer.intToHexStringFormatted(sensorId, 1, false) + " not supported. "
 					+ "File byte index " + UtilShimmer.intToHexStringFormatted(dataBlockStartByteIndexInFile, 4, true)
@@ -1802,20 +1926,147 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 	}
 
 	public void parseDataBlockData(DataBlockDetails dataBlockDetails, byte[] byteBuffer, int currentByteIndex, COMMUNICATION_TYPE commType) {
+		if(dataBlockDetails.datablockSensorId == DATABLOCK_SENSOR_ID.LSM6DSV) {
+			parseDataBlockDataLsm6dsv(dataBlockDetails, byteBuffer, currentByteIndex, commType);
+			return;
+		}
+
 		double timeMsCurrentSample = dataBlockDetails.getStartTimeRwcMs();
-		
+
 		for(int y=0;y<dataBlockDetails.getSampleCount();y++) {
 			byte[] byteBuf = new byte[dataBlockDetails.dataPacketSize];
 			System.arraycopy(byteBuffer, currentByteIndex, byteBuf, 0, byteBuf.length);
-			
+
 			ObjectCluster ojcCurrent = buildMsgForSensorList(byteBuf, commType, dataBlockDetails.listOfSensorClassKeys, timeMsCurrentSample);
 			dataHandler(ojcCurrent);
 			dataBlockDetails.setOjcArrayAtIndex(y, ojcCurrent);
-			
+
 			timeMsCurrentSample += (dataBlockDetails.getTimestampDiffInS() * 1000);
 
 			currentByteIndex += dataBlockDetails.dataPacketSize;
 		}
+	}
+
+	/** LSM6DSV tag values within the FIFO TAG_CNT byte (bits 7:3). */
+	private static final int LSM6DSV_TAG_GYRO = 0x01;
+	private static final int LSM6DSV_TAG_ACCEL = 0x02;
+	private static final int LSM6DSV_TAG_MAG = 0x0E;
+
+	/**
+	 * Count the aligned (directly-sampled) accel or gyro samples in an LSM6DSV
+	 * tagged-FIFO block - used to drive per-sample timing. Accel and gyro share the
+	 * same ODR and are interleaved 1:1; timestamp (tag 0x04) and other entries are
+	 * ignored.
+	 */
+	private int countLsm6dsvAlignedSamples(byte[] byteBuffer, int entriesStart, int numEntries) {
+		boolean accelEn = isSensorEnabled(Configuration.Verisense.SENSOR_ID.LSM6DSV_ACCEL);
+		int refTag = accelEn ? LSM6DSV_TAG_ACCEL : LSM6DSV_TAG_GYRO;
+		int count = 0;
+		for(int k=0;k<numEntries;k++) {
+			int tag = ((byteBuffer[entriesStart + k*7] & 0xFF) >> 3) & 0x1F;
+			if(tag==refTag) { count++; }
+		}
+		return count;
+	}
+
+	/**
+	 * Dedicated parser for the LSM6DSV variable-length tagged FIFO. The block is
+	 * {@code [2-byte NUM_SAMPLES][N x 7-byte entries]} where each entry is
+	 * {@code [TAG_CNT][X][Y][Z]} (3 x int16 LE) and the 5-bit tag (TAG_CNT bits 7:3)
+	 * distinguishes accel (0x02), gyro (0x01) and mag (0x0E) streams; timestamp
+	 * entries (0x04) are skipped.
+	 * <p>
+	 * Accel and gyro share the LSM6DSV ODR and are interleaved 1:1, so they are
+	 * emitted as aligned samples through {@link #buildMsgForSensorList}. (Mag is read
+	 * via the sensor hub at a different rate; full per-stream mag timestamping is TODO
+	 * - mag bytes are currently left zero so accel/gyro stay byte-aligned.)
+	 */
+	private void parseDataBlockDataLsm6dsv(DataBlockDetails dataBlockDetails, byte[] byteBuffer, int currentByteIndex, COMMUNICATION_TYPE commType) {
+		int numEntries = (byteBuffer[currentByteIndex] & 0xFF) | ((byteBuffer[currentByteIndex+1] & 0xFF) << 8);
+		int entriesStart = currentByteIndex + 2;
+
+		List<byte[]> accelSamples = new ArrayList<byte[]>();
+		List<byte[]> gyroSamples = new ArrayList<byte[]>();
+		List<byte[]> magSamples = new ArrayList<byte[]>();
+		for(int k=0;k<numEntries;k++) {
+			int eo = entriesStart + k*7;
+			int tag = ((byteBuffer[eo] & 0xFF) >> 3) & 0x1F;
+			if(tag==LSM6DSV_TAG_ACCEL || tag==LSM6DSV_TAG_GYRO || tag==LSM6DSV_TAG_MAG) {
+				byte[] xyz = new byte[6];
+				System.arraycopy(byteBuffer, eo+1, xyz, 0, 6);
+				if(tag==LSM6DSV_TAG_ACCEL) { accelSamples.add(xyz); }
+				else if(tag==LSM6DSV_TAG_GYRO) { gyroSamples.add(xyz); }
+				else { magSamples.add(xyz); }
+			}
+			// tag 0x04 (timestamp) intentionally skipped
+		}
+
+		boolean accelEn = isSensorEnabled(Configuration.Verisense.SENSOR_ID.LSM6DSV_ACCEL);
+		boolean gyroEn = isSensorEnabled(Configuration.Verisense.SENSOR_ID.LSM6DSV_GYRO);
+		boolean magEn = isSensorEnabled(Configuration.Verisense.SENSOR_ID.LSM6DSV_MAG);
+
+		int alignedCount = accelEn ? accelSamples.size() : (gyroEn ? gyroSamples.size() : 0);
+		int magCount = magEn ? magSamples.size() : 0;
+		dataBlockDetails.setupOjcArray(alignedCount + magCount);
+
+		// SensorDetails for per-stream enable toggling. Accel + gyro are synchronous (same
+		// ODR, 1:1 interleaved) so they share one OJC per timestamp. Mag is read via the
+		// LSM6DSV sensor hub at its own (lower) cadence, so it is emitted as its own OJC
+		// stream - the CSV writer keeps streams separate by per-OJC channel filtering, but
+		// we must NOT let the accel/gyro OJCs carry mag (toggle mag off for pass 1) nor the
+		// mag OJCs carry accel/gyro (toggle them off for pass 2).
+		AbstractSensor sensorClass = getSensorClass(SENSORS.LSM6DSV);
+		SensorDetails accelDet = (sensorClass!=null)? sensorClass.mSensorMap.get(Configuration.Verisense.SENSOR_ID.LSM6DSV_ACCEL) : null;
+		SensorDetails gyroDet = (sensorClass!=null)? sensorClass.mSensorMap.get(Configuration.Verisense.SENSOR_ID.LSM6DSV_GYRO) : null;
+		SensorDetails magDet = (sensorClass!=null)? sensorClass.mSensorMap.get(Configuration.Verisense.SENSOR_ID.LSM6DSV_MAG) : null;
+		boolean accelOrig = accelDet!=null && accelDet.isEnabled();
+		boolean gyroOrig = gyroDet!=null && gyroDet.isEnabled();
+		boolean magOrig = magDet!=null && magDet.isEnabled();
+
+		int ojcIndex = 0;
+		double startTimeMs = dataBlockDetails.getStartTimeRwcMs();
+		double alignedDiffMs = dataBlockDetails.getTimestampDiffInS() * 1000;
+
+		// Pass 1: aligned accel/gyro (mag disabled so these OJCs carry no mag channels)
+		if(magDet!=null) { magDet.setIsEnabled(false); }
+		int alignedPacketSize = getExpectedDataPacketSize(SENSORS.LSM6DSV);
+		double timeMsCurrentSample = startTimeMs;
+		for(int i=0;i<alignedCount;i++) {
+			byte[] byteBuf = new byte[alignedPacketSize];
+			int offset = 0;
+			if(accelEn && i<accelSamples.size()) { System.arraycopy(accelSamples.get(i), 0, byteBuf, offset, 6); }
+			if(accelEn) { offset += 6; }
+			if(gyroEn && i<gyroSamples.size()) { System.arraycopy(gyroSamples.get(i), 0, byteBuf, offset, 6); }
+
+			ObjectCluster ojcCurrent = buildMsgForSensorList(byteBuf, commType, dataBlockDetails.listOfSensorClassKeys, timeMsCurrentSample);
+			dataHandler(ojcCurrent);
+			dataBlockDetails.setOjcArrayAtIndex(ojcIndex++, ojcCurrent);
+			timeMsCurrentSample += alignedDiffMs;
+		}
+
+		// Pass 2: mag stream (only mag enabled), spread evenly across the same block duration
+		if(magCount>0) {
+			if(accelDet!=null) { accelDet.setIsEnabled(false); }
+			if(gyroDet!=null) { gyroDet.setIsEnabled(false); }
+			if(magDet!=null) { magDet.setIsEnabled(true); }
+			int magPacketSize = getExpectedDataPacketSize(SENSORS.LSM6DSV);
+			double blockDurationMs = alignedDiffMs * alignedCount;
+			double magDiffMs = (blockDurationMs>0)? blockDurationMs/magCount : 0;
+			double magTimeMs = startTimeMs;
+			for(int i=0;i<magCount;i++) {
+				byte[] byteBuf = new byte[magPacketSize];
+				System.arraycopy(magSamples.get(i), 0, byteBuf, 0, 6);
+				ObjectCluster ojcCurrent = buildMsgForSensorList(byteBuf, commType, dataBlockDetails.listOfSensorClassKeys, magTimeMs);
+				dataHandler(ojcCurrent);
+				dataBlockDetails.setOjcArrayAtIndex(ojcIndex++, ojcCurrent);
+				magTimeMs += magDiffMs;
+			}
+		}
+
+		// restore original per-stream enabled states
+		if(accelDet!=null) { accelDet.setIsEnabled(accelOrig); }
+		if(gyroDet!=null) { gyroDet.setIsEnabled(gyroOrig); }
+		if(magDet!=null) { magDet.setIsEnabled(magOrig); }
 	}
 
 	@Override
@@ -1971,6 +2222,14 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 		AbstractSensor abstractSensor = getSensorClass(SENSORS.LSM6DS3);
 		if(abstractSensor!=null && abstractSensor instanceof SensorLSM6DS3) {
 			return (SensorLSM6DS3) abstractSensor;
+		}
+		return null;
+	}
+
+	public SensorLSM6DSV getSensorLSM6DSV() {
+		AbstractSensor abstractSensor = getSensorClass(SENSORS.LSM6DSV);
+		if(abstractSensor!=null && abstractSensor instanceof SensorLSM6DSV) {
+			return (SensorLSM6DSV) abstractSensor;
 		}
 		return null;
 	}

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/VerisenseDevice.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/VerisenseDevice.java
@@ -1945,15 +1945,20 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 		
 		DataBlockDetails dataBlockDetails = null;
 		DATABLOCK_SENSOR_ID[] payloadSensorIdValues = DATABLOCK_SENSOR_ID.values();
-		// Only IDs with a parse implementation are accepted. The enum intentionally
-		// declares the remaining second-generation block IDs (LIGHT, ALGO_HUB,
-		// SKIN_TEMP, FLICKER) ahead of their parser support - accepting them here
-		// without a getSensorKeysForDatablockId()/calculateFifoBlockSize() handler
-		// would corrupt the parse, so they are rejected with the informative
-		// exception below until their decoders are implemented.
-		// Parse-supported block ids: everything up to LIGHT (7), plus SKIN_TEMP (9).
-		// ALGO_HUB (8) and FLICKER (10) still fail loudly below until their decoders land.
-		if(sensorId>0 && (sensorId<=DATABLOCK_SENSOR_ID.LIGHT.ordinal() || sensorId==DATABLOCK_SENSOR_ID.SKIN_TEMP.ordinal())) {
+		// Only IDs with a parse implementation are accepted; anything else is
+		// rejected with the informative exception below (accepting an unhandled ID
+		// would corrupt the parse). Parse-supported: the gen-1 ids (1-5) on any
+		// payload design, and the second-generation ids LSM6DSV (6), LIGHT (7) and
+		// SKIN_TEMP (9) on payload design v13+ only - their sensor classes are only
+		// registered for v13+ devices, so a (corrupt) pre-v13 file carrying one of
+		// those ids must fail loudly here rather than NPE further down. ALGO_HUB (8)
+		// and FLICKER (10) still fail loudly until their decoders land.
+		boolean isGen2DataBlockSensorId = sensorId==DATABLOCK_SENSOR_ID.LSM6DSV.ordinal()
+				|| sensorId==DATABLOCK_SENSOR_ID.LIGHT.ordinal()
+				|| sensorId==DATABLOCK_SENSOR_ID.SKIN_TEMP.ordinal();
+		boolean isParseSupported = (sensorId>0 && sensorId<DATABLOCK_SENSOR_ID.LSM6DSV.ordinal())
+				|| (isGen2DataBlockSensorId && isPayloadDesignV13orAbove());
+		if(isParseSupported) {
 			DATABLOCK_SENSOR_ID datablockSensorId = payloadSensorIdValues[sensorId];
 			
 			List<SENSORS> listOfSensorClassKeys = getOrCreateListOfSensorClassKeysForDataBlockId(datablockSensorId);
@@ -2086,9 +2091,9 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 	 * entries (0x04) are skipped.
 	 * <p>
 	 * Accel and gyro share the LSM6DSV ODR and are interleaved 1:1, so they are
-	 * emitted as aligned samples through {@link #buildMsgForSensorList}. (Mag is read
-	 * via the sensor hub at a different rate; full per-stream mag timestamping is TODO
-	 * - mag bytes are currently left zero so accel/gyro stay byte-aligned.)
+	 * emitted as aligned samples through {@link #buildMsgForSensorList}. Mag is read
+	 * via the sensor hub at its own (lower) cadence and is emitted as a separate OJC
+	 * stream (pass 2 below), its samples spread evenly across the block duration.
 	 */
 	private void parseDataBlockDataLsm6dsv(DataBlockDetails dataBlockDetails, byte[] byteBuffer, int currentByteIndex, COMMUNICATION_TYPE commType) {
 		int numEntries = (byteBuffer[currentByteIndex] & 0xFF) | ((byteBuffer[currentByteIndex+1] & 0xFF) << 8);
@@ -2101,8 +2106,11 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 		// The aligned (accel/gyro) reference stream drives per-sample timing and, for
 		// midday/midnight-split blocks, defines each half's share of the FIFO. Each mag
 		// entry records how many reference entries preceded it in the FIFO so it can be
-		// assigned to the correct half by arrival order.
-		int refTag = accelEn ? LSM6DSV_TAG_ACCEL : LSM6DSV_TAG_GYRO;
+		// assigned to the correct half by arrival order. When neither accel nor gyro is
+		// enabled the mag itself acts as the reference (mirrors
+		// countLsm6dsvAlignedSamples; not firmware-producible today but expressible).
+		boolean magIsReference = !accelEn && !gyroEn;
+		int refTag = accelEn ? LSM6DSV_TAG_ACCEL : (gyroEn ? LSM6DSV_TAG_GYRO : LSM6DSV_TAG_MAG);
 		List<byte[]> accelSamples = new ArrayList<byte[]>();
 		List<byte[]> gyroSamples = new ArrayList<byte[]>();
 		List<byte[]> magSamples = new ArrayList<byte[]>();
@@ -2126,28 +2134,41 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 		}
 
 		int alignedCountFull = accelEn ? accelSamples.size() : (gyroEn ? gyroSamples.size() : 0);
+		int referenceCountFull = magIsReference ? magSamples.size() : alignedCountFull;
 
 		// Midday/midnight-split support: both halves of a split block are handed the SAME
 		// raw block bytes (see the byte-offset walk in PayloadContentsDetailsV8orAbove);
-		// each half parses only its own aligned-sample range. The metadata-time split set
-		// each part's sampleCount in the aligned-sample domain.
-		int alignedFrom = 0;
-		int alignedTo = alignedCountFull;
+		// each half parses only its own reference-sample range. The metadata-time split
+		// set each part's sampleCount in the reference-stream domain (aligned accel/gyro,
+		// or mag when it is the reference).
+		int refFrom = 0;
+		int refTo = referenceCountFull;
 		if(dataBlockDetails.isFirstPartOfSplitDataBlock()) {
-			alignedTo = Math.min(dataBlockDetails.getSampleCount(), alignedCountFull);
+			refTo = Math.min(dataBlockDetails.getSampleCount(), referenceCountFull);
 		} else if(dataBlockDetails.isSecondPartOfSplitDataBlock()) {
-			alignedFrom = Math.max(0, alignedCountFull - dataBlockDetails.getSampleCount());
+			refFrom = Math.max(0, referenceCountFull - dataBlockDetails.getSampleCount());
 		}
+		// The aligned (pass 1) emission range: equal to the reference range normally,
+		// empty when the mag is the reference stream (no accel/gyro to emit).
+		int alignedFrom = magIsReference ? 0 : refFrom;
+		int alignedTo = magIsReference ? 0 : refTo;
 		int alignedCount = alignedTo - alignedFrom;
 
-		// Mag entries are assigned to a split half by FIFO arrival order relative to the
-		// aligned boundary: an entry that arrived before the first aligned sample of the
-		// second half belongs to the first half.
+		// Mag selection per split half. With an aligned reference, mag entries are
+		// assigned by FIFO arrival order relative to the aligned boundary (an entry
+		// that arrived before the first aligned sample of the second half belongs to
+		// the first half). When the mag IS the reference, each mag entry's recorded
+		// position is its own index, so the range check is direct.
 		List<byte[]> magSamplesPart = new ArrayList<byte[]>();
 		if(magEn) {
 			for(int i=0;i<magSamples.size();i++) {
 				int pos = magAlignedPos.get(i);
-				boolean inPart = dataBlockDetails.isSecondPartOfSplitDataBlock() ? (pos > alignedFrom) : (pos <= alignedTo);
+				boolean inPart;
+				if(magIsReference) {
+					inPart = (pos >= refFrom && pos < refTo);
+				} else {
+					inPart = dataBlockDetails.isSecondPartOfSplitDataBlock() ? (pos > refFrom) : (pos <= refTo);
+				}
 				if(inPart) { magSamplesPart.add(magSamples.get(i)); }
 			}
 		}

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/VerisenseDevice.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/VerisenseDevice.java
@@ -578,7 +578,10 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 		if(commType==COMMUNICATION_TYPE.SD && isPayloadDesignV13orAbove()) {
 			// Second-generation: ACCEL2/GYRO enable bits (PAYLOAD_CONFIG0 bits 6/5) map to the
 			// LSM6DSV (not LSM6DS3); LIS2MDL mag enable is in GEN_CFG_3 (abs byte 29) bit 2.
-			enabledSensors = 0;
+			// The PAYLOAD_CONFIG2-derived enables (GSR/VBATT/PPG, bits 8-15, computed above)
+			// are unchanged from gen-1 and must be preserved - only remap the gen-1
+			// PAYLOAD_CONFIG0 accel1/accel2/gyro bits (0xE0).
+			enabledSensors &= ~0xE0L;
 			int gen2Cfg0 = configBytes[PAYLOAD_CONFIG_BYTE_INDEX.PAYLOAD_CONFIG0] & 0xFF;
 			if((gen2Cfg0 & (1<<6))!=0) { enabledSensors |= Configuration.Verisense.SensorBitmap.LSM6DSV_ACCEL; }
 			if((gen2Cfg0 & (1<<5))!=0) { enabledSensors |= Configuration.Verisense.SensorBitmap.LSM6DSV_GYRO; }

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/VerisenseDevice.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/VerisenseDevice.java
@@ -711,7 +711,8 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 	}
 
 	/**
-	 * Second-generation payload design (firmware "v9" / 30-byte config header).
+	 * Second-generation payload design (firmware "v9" / 32-byte config header,
+	 * bytes 4..35, of which bytes 34..35 are the calibration-blob CRC).
 	 * @see PayloadContentsDetails#isPayloadDesignV13orAbove(ShimmerVerObject)
 	 */
 	public boolean isPayloadDesignV13orAbove() {
@@ -1956,14 +1957,24 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 	private static final int LSM6DSV_TAG_MAG = 0x0E;
 
 	/**
-	 * Count the aligned (directly-sampled) accel or gyro samples in an LSM6DSV
-	 * tagged-FIFO block - used to drive per-sample timing. Accel and gyro share the
-	 * same ODR and are interleaved 1:1; timestamp (tag 0x04) and other entries are
-	 * ignored.
+	 * Count the reference-stream samples in an LSM6DSV tagged-FIFO block - used to
+	 * drive per-sample timing. Accel and gyro share the same ODR and are interleaved
+	 * 1:1 so either can act as the reference; if neither is enabled (a mag-only
+	 * enable configuration - not currently producible by the firmware as the sensor
+	 * hub needs accel/gyro running, but expressible in the header) the mag stream is
+	 * counted instead. Timestamp (tag 0x04) and other entries are ignored.
 	 */
 	private int countLsm6dsvAlignedSamples(byte[] byteBuffer, int entriesStart, int numEntries) {
-		boolean accelEn = isSensorEnabled(Configuration.Verisense.SENSOR_ID.LSM6DSV_ACCEL);
-		int refTag = accelEn ? LSM6DSV_TAG_ACCEL : LSM6DSV_TAG_GYRO;
+		int refTag;
+		if(isSensorEnabled(Configuration.Verisense.SENSOR_ID.LSM6DSV_ACCEL)) {
+			refTag = LSM6DSV_TAG_ACCEL;
+		} else if(isSensorEnabled(Configuration.Verisense.SENSOR_ID.LSM6DSV_GYRO)) {
+			refTag = LSM6DSV_TAG_GYRO;
+		} else if(isSensorEnabled(Configuration.Verisense.SENSOR_ID.LSM6DSV_MAG)) {
+			refTag = LSM6DSV_TAG_MAG;
+		} else {
+			return 0;
+		}
 		int count = 0;
 		for(int k=0;k<numEntries;k++) {
 			int tag = ((byteBuffer[entriesStart + k*7] & 0xFF) >> 3) & 0x1F;
@@ -2030,46 +2041,62 @@ public class VerisenseDevice extends ShimmerDevice implements Serializable{
 		double startTimeMs = dataBlockDetails.getStartTimeRwcMs();
 		double alignedDiffMs = dataBlockDetails.getTimestampDiffInS() * 1000;
 
-		// Pass 1: aligned accel/gyro (mag disabled so these OJCs carry no mag channels)
-		if(magDet!=null) { magDet.setIsEnabled(false); }
-		int alignedPacketSize = getExpectedDataPacketSize(SENSORS.LSM6DSV);
-		double timeMsCurrentSample = startTimeMs;
-		for(int i=0;i<alignedCount;i++) {
-			byte[] byteBuf = new byte[alignedPacketSize];
-			int offset = 0;
-			if(accelEn && i<accelSamples.size()) { System.arraycopy(accelSamples.get(i), 0, byteBuf, offset, 6); }
-			if(accelEn) { offset += 6; }
-			if(gyroEn && i<gyroSamples.size()) { System.arraycopy(gyroSamples.get(i), 0, byteBuf, offset, 6); }
+		// Guarantee the per-stream enabled states are restored even if parsing throws
+		// mid-pass - otherwise the device would be left with corrupted enable state for
+		// the remainder of the file.
+		try {
+			// Pass 1: aligned accel/gyro (mag disabled so these OJCs carry no mag channels)
+			if(alignedCount>0) {
+				if(magDet!=null) { magDet.setIsEnabled(false); }
+				int alignedPacketSize = getExpectedDataPacketSize(SENSORS.LSM6DSV);
+				double timeMsCurrentSample = startTimeMs;
+				for(int i=0;i<alignedCount;i++) {
+					byte[] byteBuf = new byte[alignedPacketSize];
+					int offset = 0;
+					if(accelEn && i<accelSamples.size()) { System.arraycopy(accelSamples.get(i), 0, byteBuf, offset, 6); }
+					if(accelEn) { offset += 6; }
+					if(gyroEn && i<gyroSamples.size()) { System.arraycopy(gyroSamples.get(i), 0, byteBuf, offset, 6); }
 
-			ObjectCluster ojcCurrent = buildMsgForSensorList(byteBuf, commType, dataBlockDetails.listOfSensorClassKeys, timeMsCurrentSample);
-			dataHandler(ojcCurrent);
-			dataBlockDetails.setOjcArrayAtIndex(ojcIndex++, ojcCurrent);
-			timeMsCurrentSample += alignedDiffMs;
-		}
-
-		// Pass 2: mag stream (only mag enabled), spread evenly across the same block duration
-		if(magCount>0) {
-			if(accelDet!=null) { accelDet.setIsEnabled(false); }
-			if(gyroDet!=null) { gyroDet.setIsEnabled(false); }
-			if(magDet!=null) { magDet.setIsEnabled(true); }
-			int magPacketSize = getExpectedDataPacketSize(SENSORS.LSM6DSV);
-			double blockDurationMs = alignedDiffMs * alignedCount;
-			double magDiffMs = (blockDurationMs>0)? blockDurationMs/magCount : 0;
-			double magTimeMs = startTimeMs;
-			for(int i=0;i<magCount;i++) {
-				byte[] byteBuf = new byte[magPacketSize];
-				System.arraycopy(magSamples.get(i), 0, byteBuf, 0, 6);
-				ObjectCluster ojcCurrent = buildMsgForSensorList(byteBuf, commType, dataBlockDetails.listOfSensorClassKeys, magTimeMs);
-				dataHandler(ojcCurrent);
-				dataBlockDetails.setOjcArrayAtIndex(ojcIndex++, ojcCurrent);
-				magTimeMs += magDiffMs;
+					ObjectCluster ojcCurrent = buildMsgForSensorList(byteBuf, commType, dataBlockDetails.listOfSensorClassKeys, timeMsCurrentSample);
+					dataHandler(ojcCurrent);
+					dataBlockDetails.setOjcArrayAtIndex(ojcIndex++, ojcCurrent);
+					timeMsCurrentSample += alignedDiffMs;
+				}
 			}
-		}
 
-		// restore original per-stream enabled states
-		if(accelDet!=null) { accelDet.setIsEnabled(accelOrig); }
-		if(gyroDet!=null) { gyroDet.setIsEnabled(gyroOrig); }
-		if(magDet!=null) { magDet.setIsEnabled(magOrig); }
+			// Pass 2: mag stream (only mag enabled), spread evenly across the block duration
+			if(magCount>0) {
+				if(accelDet!=null) { accelDet.setIsEnabled(false); }
+				if(gyroDet!=null) { gyroDet.setIsEnabled(false); }
+				if(magDet!=null) { magDet.setIsEnabled(true); }
+				int magPacketSize = getExpectedDataPacketSize(SENSORS.LSM6DSV);
+				double blockDurationMs = alignedDiffMs * alignedCount;
+				if(!(blockDurationMs>0)) { // covers 0 and NaN (no aligned stream -> 0 * Infinity)
+					// Mag-only enable configuration (no aligned accel/gyro stream to derive the
+					// block duration from): fall back to the configured mag output rate. Not
+					// currently producible by the firmware (the sensor hub requires accel/gyro
+					// to be running) but handled defensively.
+					SensorLSM6DSV sensorLsm6dsv = getSensorLSM6DSV();
+					double magRateHz = (sensorLsm6dsv!=null)? sensorLsm6dsv.getMagRateFreq() : 0;
+					blockDurationMs = (magRateHz>0)? (magCount * (1000.0/magRateHz)) : 0;
+				}
+				double magDiffMs = (blockDurationMs>0)? blockDurationMs/magCount : 0;
+				double magTimeMs = startTimeMs;
+				for(int i=0;i<magCount;i++) {
+					byte[] byteBuf = new byte[magPacketSize];
+					System.arraycopy(magSamples.get(i), 0, byteBuf, 0, 6);
+					ObjectCluster ojcCurrent = buildMsgForSensorList(byteBuf, commType, dataBlockDetails.listOfSensorClassKeys, magTimeMs);
+					dataHandler(ojcCurrent);
+					dataBlockDetails.setOjcArrayAtIndex(ojcIndex++, ojcCurrent);
+					magTimeMs += magDiffMs;
+				}
+			}
+		} finally {
+			// restore original per-stream enabled states
+			if(accelDet!=null) { accelDet.setIsEnabled(accelOrig); }
+			if(gyroDet!=null) { gyroDet.setIsEnabled(gyroOrig); }
+			if(magDet!=null) { magDet.setIsEnabled(magOrig); }
+		}
 	}
 
 	@Override

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/payloaddesign/AsmBinaryFileConstants.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/payloaddesign/AsmBinaryFileConstants.java
@@ -42,6 +42,11 @@ public class AsmBinaryFileConstants {
 		// Second-generation (payload design v13) only: GEN_CFG_3 at abs byte 29 (rel 25)
 		// carries the mag/light/skin-temp/algo-hub enables + LED mode.
 		public static final int GEN_CFG_3 = 25;
+		/** Second-generation only: ambient-light gain index in bits 2:0 and the
+		 * dark-channel enable in bit 7 (abs byte 30). */
+		public static final int LIGHT_GAIN_AND_DARK = 26;
+		/** Second-generation only: ambient-light exposure index (abs byte 31). */
+		public static final int LIGHT_EXPOSURE = 27;
 	}
 	
 	public class BYTE_COUNT {

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/payloaddesign/AsmBinaryFileConstants.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/payloaddesign/AsmBinaryFileConstants.java
@@ -39,6 +39,9 @@ public class AsmBinaryFileConstants {
 		public static final int PAYLOAD_CONFIG11 = 22;
 		public static final int PAYLOAD_CONFIG12 = 23;
 		public static final int PAYLOAD_CONFIG13 = 24;
+		// Second-generation (payload design v13) only: GEN_CFG_3 at abs byte 29 (rel 25)
+		// carries the mag/light/skin-temp/algo-hub enables + LED mode.
+		public static final int GEN_CFG_3 = 25;
 	}
 	
 	public class BYTE_COUNT {

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/payloaddesign/AsmBinaryFileConstants.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/payloaddesign/AsmBinaryFileConstants.java
@@ -47,6 +47,9 @@ public class AsmBinaryFileConstants {
 		public static final int LIGHT_GAIN_AND_DARK = 26;
 		/** Second-generation only: ambient-light exposure index (abs byte 31). */
 		public static final int LIGHT_EXPOSURE = 27;
+		/** Second-generation only: skin-temp config (abs byte 32) - bit 0 measType
+		 * (0=medical/1=extended), bits 3:1 MLX90632 refresh-rate code. */
+		public static final int SKIN_TEMP_CONFIG = 28;
 	}
 	
 	public class BYTE_COUNT {

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/payloaddesign/DataBlockDetails.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/payloaddesign/DataBlockDetails.java
@@ -24,14 +24,24 @@ public class DataBlockDetails implements Serializable {
 	
 	private static final long serialVersionUID = -3695586952435188960L;
 	
-	/** This is the ENUM of the DataBlock ID as set in FW */
+	/** This is the ENUM of the DataBlock ID as set in FW. The ordinal of each
+	 * entry MUST match the firmware {@code SENSOR_IDS} enum
+	 * (verisense-firmware: Includes/ASM_common_source/SensorDataManagement/recordBuffers.h)
+	 * because the parser maps the data-block sensor-id byte straight to
+	 * {@code DATABLOCK_SENSOR_ID.values()[sensorId]}. */
 	public enum DATABLOCK_SENSOR_ID {
-		NONE,
-		ADC,
-		ACCEL_1,
-		GYRO_ACCEL2,
-		PPG,
-		BIOZ
+		NONE,			// 0
+		ADC,			// 1
+		ACCEL_1,		// 2  - LIS2DW12
+		GYRO_ACCEL2,	// 3  - LSM6DS3
+		PPG,			// 4  - MAX86150/MAX86916 (gen1) or MAX86176 via the MAX32674 hub (gen2)
+		BIOZ,			// 5  - MAX30001/2 (reserved, not currently emitted)
+		// --- Second-generation hardware (SR68-9/10, SR61-5/6) ---
+		LSM6DSV,		// 6  - LSM6DSV accel/gyro + LIS2MDL mag (via the LSM6DSV sensor hub)
+		LIGHT,			// 7  - VD6283TX45 ambient light
+		ALGO_HUB,		// 8  - MAX32674 algorithm hub (HR/SpO2/activity/skin-contact)
+		SKIN_TEMP,		// 9  - MLX90632 skin temperature
+		FLICKER			// 10 - VD6283TX45 flicker (RESERVED, not yet emitted by firmware)
 	}
 
 	public DATABLOCK_SENSOR_ID datablockSensorId;

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/payloaddesign/DataBlockDetails.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/payloaddesign/DataBlockDetails.java
@@ -53,6 +53,15 @@ public class DataBlockDetails implements Serializable {
 	private VerisenseTimeDetails timeDetailsUcClock = new VerisenseTimeDetails();
 	
 	public int qtySensorDataBytesInDatablock;
+	/**
+	 * The raw on-disk sensor-data byte length as parsed from the payload. Unlike
+	 * {@link #qtySensorDataBytesInDatablock} this is never recomputed by the
+	 * midday/midnight CSV-split logic ({@link #setSampleCountAndUpdateDataBlockSize(int)})
+	 * - essential for variable-length blocks (e.g. the LSM6DSV tagged FIFO, whose raw
+	 * length includes timestamp-tag and magnetometer entries that don't map 1:1 to
+	 * aligned samples). Always use this for advancing byte offsets through the payload.
+	 */
+	private int qtySensorDataBytesInDatablockRaw;
 	public int dataPacketSize;
 	private double samplingRate;
 	
@@ -102,9 +111,14 @@ public class DataBlockDetails implements Serializable {
 	
 	public void setMetadata(int dataBlockSizeSensorData, int dataPacketSize, double samplingRate) {
 		this.qtySensorDataBytesInDatablock = dataBlockSizeSensorData;
+		this.qtySensorDataBytesInDatablockRaw = dataBlockSizeSensorData;
 		this.dataPacketSize = dataPacketSize;
 		setSamplingRate(samplingRate);
 		calculateSampleCount();
+	}
+
+	public int getQtySensorDataBytesInDatablockRaw() {
+		return qtySensorDataBytesInDatablockRaw;
 	}
 	
 	public void setRwcEndTimeMinutesAndCalculateTimings(long rtcEndTimeMinutes) {

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/payloaddesign/PayloadContentsDetails.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/payloaddesign/PayloadContentsDetails.java
@@ -351,7 +351,12 @@ public abstract class PayloadContentsDetails implements Serializable {
 	protected int parseBatteryVoltageBytes(int currentByteIndex) {
 		byte[] batteryVoltageArray = new byte[BYTE_COUNT.PAYLOAD_CONTENTS_BATTERY_VOLTAGE];
 		System.arraycopy(byteBuffer, currentByteIndex, batteryVoltageArray, 0, BYTE_COUNT.PAYLOAD_CONTENTS_BATTERY_VOLTAGE);
-		long batteryVoltageCal = UtilParseData.parseData(batteryVoltageArray, CHANNEL_DATA_TYPE.UINT12, CHANNEL_DATA_ENDIAN.LSB);
+		// Second-generation firmware writes the full battery voltage in mV which can
+		// exceed 12-bits (e.g. 4133 mV) - masking to UINT12 would wrap it (-> 37 mV).
+		// Keep the legacy UINT12 mask for gen-1 to preserve existing behaviour.
+		CHANNEL_DATA_TYPE battChannelDataType = isPayloadDesignV13orAbove(verisenseDevice.getShimmerVerObject())
+				? CHANNEL_DATA_TYPE.UINT16 : CHANNEL_DATA_TYPE.UINT12;
+		long batteryVoltageCal = UtilParseData.parseData(batteryVoltageArray, battChannelDataType, CHANNEL_DATA_ENDIAN.LSB);
 		setBatteryVoltage(batteryVoltageCal);
 		currentByteIndex += batteryVoltageArray.length;
 		return currentByteIndex;

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/payloaddesign/PayloadContentsDetails.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/payloaddesign/PayloadContentsDetails.java
@@ -264,10 +264,12 @@ public abstract class PayloadContentsDetails implements Serializable {
 
 	/**
 	 * Second-generation hardware payload design (SR68-9/10, SR61-5/6). The
-	 * firmware calls this its "payload design v9" (30-byte config header, bytes
-	 * 4..33). It is NOT the same as {@link #isPayloadDesignV9orAbove(ShimmerVerObject)}
-	 * above, which is this driver's own internal sequence (FW v1.02.074). Gen-2
-	 * firmware (v1.04.024+) is the next step after V12 in this driver's numbering.
+	 * firmware calls this its "payload design v9" (32-byte config header, bytes
+	 * 4..35, of which bytes 34..35 are the calibration-blob CRC). It is NOT the
+	 * same as {@link #isPayloadDesignV9orAbove(ShimmerVerObject)} above, which is
+	 * this driver's own internal sequence (FW v1.02.074). Gen-2 firmware
+	 * (v2.00.004+, confirmed on a real SR68-9) is the next step after V12 in this
+	 * driver's numbering.
 	 *
 	 * @see VerisenseDevice.FW_CHANGES#CCF_GEN2
 	 */

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/payloaddesign/PayloadContentsDetails.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/payloaddesign/PayloadContentsDetails.java
@@ -203,6 +203,13 @@ public abstract class PayloadContentsDetails implements Serializable {
 		if(isPayloadDesignV12orAbove(svo)) {
 			extendedPayloadConfigSize += 1;
 		}
+		if(isPayloadDesignV13orAbove(svo)) {
+			// Second-generation (FW v2.00.004+): config header grows from 25 to 32 bytes
+			// (abs bytes 4..35). +7 = LSM6DSV already occupies the gen-1 gyro/accel2 slots;
+			// the extra 7 are GEN_CFG_3 (29), light gain/exposure (30,31), skin-temp (32),
+			// algo report (33), and the 2-byte calibration CRC (34,35).
+			extendedPayloadConfigSize += 7;
+		}
 		return extendedPayloadConfigSize;
 	}
 
@@ -253,6 +260,19 @@ public abstract class PayloadContentsDetails implements Serializable {
 
 	public static boolean isPayloadDesignV12orAbove(ShimmerVerObject svo) {
 		return VerisenseDevice.compareFwVersions(svo, VerisenseDevice.FW_CHANGES.CCF21_010_3);
+	}
+
+	/**
+	 * Second-generation hardware payload design (SR68-9/10, SR61-5/6). The
+	 * firmware calls this its "payload design v9" (30-byte config header, bytes
+	 * 4..33). It is NOT the same as {@link #isPayloadDesignV9orAbove(ShimmerVerObject)}
+	 * above, which is this driver's own internal sequence (FW v1.02.074). Gen-2
+	 * firmware (v1.04.024+) is the next step after V12 in this driver's numbering.
+	 *
+	 * @see VerisenseDevice.FW_CHANGES#CCF_GEN2
+	 */
+	public static boolean isPayloadDesignV13orAbove(ShimmerVerObject svo) {
+		return VerisenseDevice.compareFwVersions(svo, VerisenseDevice.FW_CHANGES.CCF_GEN2);
 	}
 
 	/**

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/payloaddesign/PayloadContentsDetailsV8orAbove.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/payloaddesign/PayloadContentsDetailsV8orAbove.java
@@ -410,8 +410,25 @@ public class PayloadContentsDetailsV8orAbove extends PayloadContentsDetails {
 				if(dataBlockDetails.listOfSensorClassKeys.contains(sensorClassKey)) {
 					verisenseDevice.parseDataBlockData(dataBlockDetails, byteBuffer, currentByteIndex, COMMUNICATION_TYPE.SD);
 				}
-				// RAW size: immune to midday/midnight split recomputation (see above)
-				currentByteIndex += dataBlockDetails.getQtySensorDataBytesInDatablockRaw();
+				// Advance by the on-disk bytes THIS list entry occupies. A midday/midnight-split
+				// block appears as two consecutive entries whose recomputed sizes
+				// (dataPacketSize*sampleCount) sum to the on-disk block size, so each part must
+				// advance by its own share - advancing by the raw size for each part would count
+				// the block twice and misalign every block after it. Unsplit blocks advance by
+				// the raw size, which for the variable-length LSM6DSV tagged FIFO is the only
+				// valid measure (its raw length includes tag/mag/timestamp entries that a
+				// dataPacketSize*sampleCount recomputation cannot reproduce).
+				if(dataBlockDetails.isFirstPartOfSplitDataBlock() || dataBlockDetails.isSecondPartOfSplitDataBlock()) {
+					if(dataBlockDetails.datablockSensorId==DATABLOCK_SENSOR_ID.LSM6DSV) {
+						// A split FIFO block cannot be byte-walked from sample counts; supporting
+						// it needs a FIFO-entry-aware split. Fail loudly rather than misparse
+						// every subsequent block (no such recording exists yet - see DEV-793).
+						throw new IllegalStateException("Midday/midnight-split LSM6DSV FIFO data blocks are not supported by the byte-offset walk");
+					}
+					currentByteIndex += dataBlockDetails.qtySensorDataBytesInDatablock;
+				} else {
+					currentByteIndex += dataBlockDetails.getQtySensorDataBytesInDatablockRaw();
+				}
 				
 				dataBlockIndex++;
 				

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/payloaddesign/PayloadContentsDetailsV8orAbove.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/payloaddesign/PayloadContentsDetailsV8orAbove.java
@@ -93,11 +93,13 @@ public class PayloadContentsDetailsV8orAbove extends PayloadContentsDetails {
 		
 		// --------- End of parsing ------------------
 
-		// The ambient-light sample rate isn't stored in the payload header (only
-		// gain/exposure are) and the achieved rate differs from both the configured
-		// rate and 1/exposure (per-measurement dead time), so refine it from the
-		// data itself before the block timings are back-filled below.
-		refineLightSamplingRateFromBlockTicks();
+		// The slow sensors' achieved sample rates differ from what the payload
+		// header can tell us (the light rate isn't stored at all and the chip adds
+		// per-measurement dead time; the skin-temp output cadence is refresh-code
+		// derived but similarly approximate), so refine them from the data itself
+		// before the block timings are back-filled below.
+		refineSlowSensorSamplingRateFromBlockTicks(DATABLOCK_SENSOR_ID.LIGHT);
+		refineSlowSensorSamplingRateFromBlockTicks(DATABLOCK_SENSOR_ID.SKIN_TEMP);
 
 		// Up to, and including, payload design v10, the real-world clock time that was
 		// stored in the payload footer was the real-world time at the end of the
@@ -314,19 +316,20 @@ public class PayloadContentsDetailsV8orAbove extends PayloadContentsDetails {
 	}
 
 	/**
-	 * Derive the achieved ambient-light sample period from the spacing of
-	 * consecutive light-block end ticks and apply it to the light blocks' sampling
-	 * rate before their timings are back-filled. The light sample rate cannot be
-	 * read from the stored payload header (see SensorVD6283.getRateFreq), and each
-	 * light block holds a fixed number of samples, so
+	 * Derive a slow sensor's (ambient light / skin temp) achieved sample period
+	 * from the spacing of consecutive same-sensor block end ticks and apply it to
+	 * those blocks' sampling rate before their timings are back-filled. The
+	 * header-derived rates are only estimates (the light rate isn't stored at all
+	 * - see SensorVD6283.getRateFreq - and the skin-temp cadence is refresh-code
+	 * derived), and each block holds a fixed number of samples, so
 	 * {@code inter-block ticks / samples-per-block} is the exact per-sample period.
-	 * With fewer than two light blocks in the payload the exposure-limited
-	 * estimate the blocks were created with is left in place.
+	 * With fewer than two blocks in the payload the header-derived estimate the
+	 * blocks were created with is left in place.
 	 */
-	private void refineLightSamplingRateFromBlockTicks() {
+	private void refineSlowSensorSamplingRateFromBlockTicks(DATABLOCK_SENSOR_ID slowSensorId) {
 		List<DataBlockDetails> lightBlocks = new ArrayList<DataBlockDetails>();
 		for(DataBlockDetails dataBlockDetails:listOfDataBlocksInOrder) {
-			if(dataBlockDetails.datablockSensorId==DATABLOCK_SENSOR_ID.LIGHT) {
+			if(dataBlockDetails.datablockSensorId==slowSensorId) {
 				lightBlocks.add(dataBlockDetails);
 			}
 		}

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/payloaddesign/PayloadContentsDetailsV8orAbove.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/payloaddesign/PayloadContentsDetailsV8orAbove.java
@@ -57,7 +57,10 @@ public class PayloadContentsDetailsV8orAbove extends PayloadContentsDetails {
 			setOfPayloadSensorIds.add(dataBlockDetails.datablockSensorId);
 
 			// Update byte offset as it's passed by value into "parseDataBlockMetaData"
-			int dataBlockTotalSize = BYTE_COUNT.PAYLOAD_CONTENTS_GEN8_SENSOR_ID + BYTE_COUNT.PAYLOAD_CONTENTS_RTC_BYTES_TICKS + dataBlockDetails.qtySensorDataBytesInDatablock;  
+			// Use the RAW block size for byte-offset arithmetic - qtySensorDataBytesInDatablock
+			// can be recomputed by the midday/midnight split logic (wrongly for
+			// variable-length blocks such as the LSM6DSV tagged FIFO).
+			int dataBlockTotalSize = BYTE_COUNT.PAYLOAD_CONTENTS_GEN8_SENSOR_ID + BYTE_COUNT.PAYLOAD_CONTENTS_RTC_BYTES_TICKS + dataBlockDetails.getQtySensorDataBytesInDatablockRaw();
 			currentByteIndexInPayload += dataBlockTotalSize;
 
 			if(isParserAtEndOfBuffer(byteBuffer.length, currentByteIndexInPayload)) {
@@ -407,7 +410,8 @@ public class PayloadContentsDetailsV8orAbove extends PayloadContentsDetails {
 				if(dataBlockDetails.listOfSensorClassKeys.contains(sensorClassKey)) {
 					verisenseDevice.parseDataBlockData(dataBlockDetails, byteBuffer, currentByteIndex, COMMUNICATION_TYPE.SD);
 				}
-				currentByteIndex += dataBlockDetails.qtySensorDataBytesInDatablock;
+				// RAW size: immune to midday/midnight split recomputation (see above)
+				currentByteIndex += dataBlockDetails.getQtySensorDataBytesInDatablockRaw();
 				
 				dataBlockIndex++;
 				

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/payloaddesign/PayloadContentsDetailsV8orAbove.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/payloaddesign/PayloadContentsDetailsV8orAbove.java
@@ -327,13 +327,13 @@ public class PayloadContentsDetailsV8orAbove extends PayloadContentsDetails {
 	 * blocks were created with is left in place.
 	 */
 	private void refineSlowSensorSamplingRateFromBlockTicks(DATABLOCK_SENSOR_ID slowSensorId) {
-		List<DataBlockDetails> lightBlocks = new ArrayList<DataBlockDetails>();
+		List<DataBlockDetails> slowSensorBlocks = new ArrayList<DataBlockDetails>();
 		for(DataBlockDetails dataBlockDetails:listOfDataBlocksInOrder) {
 			if(dataBlockDetails.datablockSensorId==slowSensorId) {
-				lightBlocks.add(dataBlockDetails);
+				slowSensorBlocks.add(dataBlockDetails);
 			}
 		}
-		if(lightBlocks.size()<2) {
+		if(slowSensorBlocks.size()<2) {
 			return;
 		}
 
@@ -341,13 +341,19 @@ public class PayloadContentsDetailsV8orAbove extends PayloadContentsDetails {
 		// store real-world-clock ticks; either works as only deltas are used.
 		boolean useUcClockTicks = verisenseDevice.isPayloadDesignV11orAbove();
 		List<Double> perSamplePeriodsS = new ArrayList<Double>();
-		for(int i=1;i<lightBlocks.size();i++) {
-			VerisenseTimeDetails prev = useUcClockTicks? lightBlocks.get(i-1).getTimeDetailsUcClock():lightBlocks.get(i-1).getTimeDetailsRwc();
-			VerisenseTimeDetails curr = useUcClockTicks? lightBlocks.get(i).getTimeDetailsUcClock():lightBlocks.get(i).getTimeDetailsRwc();
-			// 3-byte tick counter at 32768 Hz; handle wrap (every ~512 s, far above the
-			// ~1 s light-block cadence).
-			long deltaTicks = (curr.getEndTimeTicks() - prev.getEndTimeTicks()) & 0xFFFFFF;
-			int sampleCount = lightBlocks.get(i).getSampleCount();
+		for(int i=1;i<slowSensorBlocks.size();i++) {
+			VerisenseTimeDetails prev = useUcClockTicks? slowSensorBlocks.get(i-1).getTimeDetailsUcClock():slowSensorBlocks.get(i-1).getTimeDetailsRwc();
+			VerisenseTimeDetails curr = useUcClockTicks? slowSensorBlocks.get(i).getTimeDetailsUcClock():slowSensorBlocks.get(i).getTimeDetailsRwc();
+			// The per-block ticks are a SUB-MINUTE counter (resets at
+			// TICKS_PER_MINUTE, 32768 Hz x 60 s - the same semantics the
+			// minute-rollover logic in backfillDataBlockUcClockOrRwcTimestamps
+			// depends on), so a minute-boundary crossing shows as a negative
+			// delta that must be re-based by one minute - NOT wrapped at 2^24.
+			long deltaTicks = curr.getEndTimeTicks() - prev.getEndTimeTicks();
+			if(deltaTicks<0) {
+				deltaTicks += (long) AsmBinaryFileConstants.TICKS_PER_MINUTE;
+			}
+			int sampleCount = slowSensorBlocks.get(i).getSampleCount();
 			if(deltaTicks>0 && sampleCount>0) {
 				perSamplePeriodsS.add((deltaTicks/32768.0)/sampleCount);
 			}
@@ -363,9 +369,30 @@ public class PayloadContentsDetailsV8orAbove extends PayloadContentsDetails {
 		}
 
 		double achievedRateHz = 1.0/medianPeriodS;
-		for(DataBlockDetails dataBlockDetails:lightBlocks) {
+		for(DataBlockDetails dataBlockDetails:slowSensorBlocks) {
 			dataBlockDetails.setSamplingRate(achievedRateHz);
 			dataBlockDetails.calculateTimestampDiffInS();
+		}
+
+		// Seed the CSV gap-splitting window from the OBSERVED period spread rather
+		// than a single-rate +/-10% band. The header-derived estimate can sit within
+		// ~1% of the band edge (VD6283: 10 Hz estimated vs ~9.09 Hz achieved), and
+		// the slow sensors' cadence is inherently bimodal (exposure vs exposure +
+		// dead time: ~100 vs ~110 ms for the light at the default exposure), so a
+		// band centred on ANY single rate can clip real spacing and fragment the
+		// CSV. Spanning [min, max] observed period with the standard tolerance keeps
+		// everything seen continuous while a dropped block (2x period) still splits.
+		// populateExpectedPayloadTsDiffLimitMapIfNeeded runs after this and is
+		// containsKey-guarded, so this seeding wins.
+		double minPeriodS = perSamplePeriodsS.get(0);
+		double maxPeriodS = perSamplePeriodsS.get(perSamplePeriodsS.size()-1);
+		double[] samplingRateLimits = new double[] {
+				(1.0/maxPeriodS)*UtilCsvSplitting.FILE_GAP_TOLERANCE_MULTIPLIER.LOWER,
+				(1.0/minPeriodS)*UtilCsvSplitting.FILE_GAP_TOLERANCE_MULTIPLIER.UPPER};
+		for(SENSORS sensorClassKey:verisenseDevice.getOrCreateListOfSensorClassKeysForDataBlockId(slowSensorId)) {
+			if(sensorClassKey!=SENSORS.CLOCK && !UtilCsvSplitting.SAMPLING_RATE_LIMITS_PER_SENSOR.containsKey(sensorClassKey)) {
+				UtilCsvSplitting.SAMPLING_RATE_LIMITS_PER_SENSOR.put(sensorClassKey, samplingRateLimits);
+			}
 		}
 	}
 

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/payloaddesign/PayloadContentsDetailsV8orAbove.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/payloaddesign/PayloadContentsDetailsV8orAbove.java
@@ -420,12 +420,18 @@ public class PayloadContentsDetailsV8orAbove extends PayloadContentsDetails {
 				// dataPacketSize*sampleCount recomputation cannot reproduce).
 				if(dataBlockDetails.isFirstPartOfSplitDataBlock() || dataBlockDetails.isSecondPartOfSplitDataBlock()) {
 					if(dataBlockDetails.datablockSensorId==DATABLOCK_SENSOR_ID.LSM6DSV) {
-						// A split FIFO block cannot be byte-walked from sample counts; supporting
-						// it needs a FIFO-entry-aware split. Fail loudly rather than misparse
-						// every subsequent block (no such recording exists yet - see DEV-793).
-						throw new IllegalStateException("Midday/midnight-split LSM6DSV FIFO data blocks are not supported by the byte-offset walk");
+						// A split tagged-FIFO block cannot be byte-walked from recomputed
+						// sample counts (the raw layout interleaves tag/mag/timestamp
+						// entries). Instead BOTH halves are handed the same raw block bytes
+						// and the LSM6DSV entry parser selects each half's aligned-sample
+						// range - so the first half advances by nothing and the second half
+						// advances by the raw on-disk size, keeping subsequent blocks aligned.
+						if(dataBlockDetails.isSecondPartOfSplitDataBlock()) {
+							currentByteIndex += dataBlockDetails.getQtySensorDataBytesInDatablockRaw();
+						}
+					} else {
+						currentByteIndex += dataBlockDetails.qtySensorDataBytesInDatablock;
 					}
-					currentByteIndex += dataBlockDetails.qtySensorDataBytesInDatablock;
 				} else {
 					currentByteIndex += dataBlockDetails.getQtySensorDataBytesInDatablockRaw();
 				}

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/payloaddesign/PayloadContentsDetailsV8orAbove.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/payloaddesign/PayloadContentsDetailsV8orAbove.java
@@ -2,6 +2,7 @@ package com.shimmerresearch.verisense.payloaddesign;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map.Entry;
@@ -91,6 +92,12 @@ public class PayloadContentsDetailsV8orAbove extends PayloadContentsDetails {
 		}
 		
 		// --------- End of parsing ------------------
+
+		// The ambient-light sample rate isn't stored in the payload header (only
+		// gain/exposure are) and the achieved rate differs from both the configured
+		// rate and 1/exposure (per-measurement dead time), so refine it from the
+		// data itself before the block timings are back-filled below.
+		refineLightSamplingRateFromBlockTicks();
 
 		// Up to, and including, payload design v10, the real-world clock time that was
 		// stored in the payload footer was the real-world time at the end of the
@@ -304,6 +311,59 @@ public class PayloadContentsDetailsV8orAbove extends PayloadContentsDetails {
 			footerLength = BYTE_COUNT.PAYLOAD_CONTENTS_FOOTER_GEN8_ONLY;
 		}
 		return (bufferLength-currentByteIndex)<(footerLength+BYTE_COUNT.PAYLOAD_CRC);
+	}
+
+	/**
+	 * Derive the achieved ambient-light sample period from the spacing of
+	 * consecutive light-block end ticks and apply it to the light blocks' sampling
+	 * rate before their timings are back-filled. The light sample rate cannot be
+	 * read from the stored payload header (see SensorVD6283.getRateFreq), and each
+	 * light block holds a fixed number of samples, so
+	 * {@code inter-block ticks / samples-per-block} is the exact per-sample period.
+	 * With fewer than two light blocks in the payload the exposure-limited
+	 * estimate the blocks were created with is left in place.
+	 */
+	private void refineLightSamplingRateFromBlockTicks() {
+		List<DataBlockDetails> lightBlocks = new ArrayList<DataBlockDetails>();
+		for(DataBlockDetails dataBlockDetails:listOfDataBlocksInOrder) {
+			if(dataBlockDetails.datablockSensorId==DATABLOCK_SENSOR_ID.LIGHT) {
+				lightBlocks.add(dataBlockDetails);
+			}
+		}
+		if(lightBlocks.size()<2) {
+			return;
+		}
+
+		// v11+ payloads store microcontroller-clock ticks per block, earlier designs
+		// store real-world-clock ticks; either works as only deltas are used.
+		boolean useUcClockTicks = verisenseDevice.isPayloadDesignV11orAbove();
+		List<Double> perSamplePeriodsS = new ArrayList<Double>();
+		for(int i=1;i<lightBlocks.size();i++) {
+			VerisenseTimeDetails prev = useUcClockTicks? lightBlocks.get(i-1).getTimeDetailsUcClock():lightBlocks.get(i-1).getTimeDetailsRwc();
+			VerisenseTimeDetails curr = useUcClockTicks? lightBlocks.get(i).getTimeDetailsUcClock():lightBlocks.get(i).getTimeDetailsRwc();
+			// 3-byte tick counter at 32768 Hz; handle wrap (every ~512 s, far above the
+			// ~1 s light-block cadence).
+			long deltaTicks = (curr.getEndTimeTicks() - prev.getEndTimeTicks()) & 0xFFFFFF;
+			int sampleCount = lightBlocks.get(i).getSampleCount();
+			if(deltaTicks>0 && sampleCount>0) {
+				perSamplePeriodsS.add((deltaTicks/32768.0)/sampleCount);
+			}
+		}
+		if(perSamplePeriodsS.isEmpty()) {
+			return;
+		}
+		// Median so a dropped block (a 2x gap) can't skew the period.
+		Collections.sort(perSamplePeriodsS);
+		double medianPeriodS = perSamplePeriodsS.get(perSamplePeriodsS.size()/2);
+		if(!(medianPeriodS>0)) {
+			return;
+		}
+
+		double achievedRateHz = 1.0/medianPeriodS;
+		for(DataBlockDetails dataBlockDetails:lightBlocks) {
+			dataBlockDetails.setSamplingRate(achievedRateHz);
+			dataBlockDetails.calculateTimestampDiffInS();
+		}
 	}
 
 	private void backfillDataBlockRwcTimestamps() {

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/sensors/SensorBattVoltageVerisense.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/sensors/SensorBattVoltageVerisense.java
@@ -262,6 +262,10 @@ public class SensorBattVoltageVerisense extends SensorBattVoltage {
 						mShimmerDevice.getShimmerVerObject().getHardwareVersion(), mShimmerDevice.getExpansionBoardRev())) {
 					// Second-generation hardware (SR61-5/6, SR68-9/10) battery-sense divider.
 					// Matches the firmware's own conversion in hal_asm_battery.c (measureBatteryVoltage).
+					// Deliberately gated on the HARDWARE revision (not isPayloadDesignV13orAbove):
+					// the divider is a property of the board's battery-sense circuit, present
+					// regardless of which firmware happens to be flashed - the firmware applies
+					// the same hardware-keyed rule.
 					calData *= BATTERY_VOLTAGE_DIVIDER_RATIO_GEN2;
 				}
 				objectCluster.addCalData(channelDetails, calData, objectCluster.getIndexKeeper()-1);

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/sensors/SensorBattVoltageVerisense.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/sensors/SensorBattVoltageVerisense.java
@@ -258,6 +258,11 @@ public class SensorBattVoltageVerisense extends SensorBattVoltage {
 
 					// Multiply by 1.988 because the battery voltage is divided by 2 before entering the BMD-340 And the value is not quite equal to 2 due to the components used in the circuit
 					calData *= BATTERY_VOLTAGE_DIVIDER_RATIO;
+				} else if(VerisenseDevice.isSecondGenerationHardware(
+						mShimmerDevice.getShimmerVerObject().getHardwareVersion(), mShimmerDevice.getExpansionBoardRev())) {
+					// Second-generation hardware (SR61-5/6, SR68-9/10) battery-sense divider.
+					// Matches the firmware's own conversion in hal_asm_battery.c (measureBatteryVoltage).
+					calData *= BATTERY_VOLTAGE_DIVIDER_RATIO_GEN2;
 				}
 				objectCluster.addCalData(channelDetails, calData, objectCluster.getIndexKeeper()-1);
 

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/sensors/SensorGSRVerisense.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/sensors/SensorGSRVerisense.java
@@ -113,8 +113,15 @@ public class SensorGSRVerisense extends SensorGSR {
 	//--------- Constructors for this class start --------------
 	public SensorGSRVerisense(ShimmerVerObject svo) {
 		super(svo);
-		
-		if (svo.getHardwareVersion() == HW_ID.VERISENSE_PULSE_PLUS) {
+
+		// The Pulse+ (SR68) and the second-generation Verisense IMU (SR61-5/6) share the
+		// same DC-based GSR front-end with its own feedback-resistor set; the GSR+ (SR62)
+		// uses the Shimmer3 values. An SR61 only gets this sensor class registered when
+		// VerisenseDevice.doesHwSupportGsr() has already confirmed HW minor >= 5, so no
+		// minor-revision check is needed here. Verified against a 33k/100k/470k resistor
+		// sweep on an SR61-5 (DEV-793 datasets B4a-c).
+		if (svo.getHardwareVersion() == HW_ID.VERISENSE_PULSE_PLUS
+				|| svo.getHardwareVersion() == HW_ID.VERISENSE_IMU) {
 			setCurrentGsrRefResistorsKohms(VERISENSE_PULSE_PLUS_GSR_REF_RESISTORS_KOHMS);
 			setCurrentGsrUncalLimitRange3(VERISENSE_PULSE_PLUS_GSR_UNCAL_LIMIT_RANGE3);
 		}

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/sensors/SensorLSM6DSV.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/sensors/SensorLSM6DSV.java
@@ -241,12 +241,15 @@ public class SensorLSM6DSV extends AbstractSensor {
 	public static final double[][] SENS_ACCEL_8G  = {{417.6759,0,0},{0,417.6759,0},{0,0,417.6759}};
 	public static final double[][] SENS_ACCEL_16G = {{208.8379,0,0},{0,208.8379,0},{0,0,208.8379}};
 
-	// Gyro sensitivity (LSB per dps) = 32768/FS_dps
-	public static final double[][] SENS_GYRO_125DPS  = {{262.144,0,0},{0,262.144,0},{0,0,262.144}};
-	public static final double[][] SENS_GYRO_250DPS  = {{131.072,0,0},{0,131.072,0},{0,0,131.072}};
-	public static final double[][] SENS_GYRO_500DPS  = {{65.536,0,0},{0,65.536,0},{0,0,65.536}};
-	public static final double[][] SENS_GYRO_1000DPS = {{32.768,0,0},{0,32.768,0},{0,0,32.768}};
-	public static final double[][] SENS_GYRO_2000DPS = {{16.384,0,0},{0,16.384,0},{0,0,16.384}};
+	// Gyro sensitivity (LSB per dps) from the ST datasheet angular-rate sensitivity
+	// (4.375 mdps/LSB at +-125 dps, doubling per range) - the same spec/values as the
+	// gen-1 LSM6DS3. NOTE: the gyro does NOT span the full 16-bit range at its nominal
+	// full scale (unlike the accel), so a 32768/FS derivation is ~12.8% off.
+	public static final double[][] SENS_GYRO_125DPS  = {{228.571428571,0,0},{0,228.571428571,0},{0,0,228.571428571}};
+	public static final double[][] SENS_GYRO_250DPS  = {{114.285714286,0,0},{0,114.285714286,0},{0,0,114.285714286}};
+	public static final double[][] SENS_GYRO_500DPS  = {{57.142857143,0,0},{0,57.142857143,0},{0,0,57.142857143}};
+	public static final double[][] SENS_GYRO_1000DPS = {{28.571428571,0,0},{0,28.571428571,0},{0,0,28.571428571}};
+	public static final double[][] SENS_GYRO_2000DPS = {{14.285714286,0,0},{0,14.285714286,0},{0,0,14.285714286}};
 
 	// Mag sensitivity (LSB per uT) = 1/0.15
 	public static final double[][] SENS_MAG = {{6.666667,0,0},{0,6.666667,0},{0,0,6.666667}};

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/sensors/SensorLSM6DSV.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/sensors/SensorLSM6DSV.java
@@ -1,0 +1,651 @@
+package com.shimmerresearch.verisense.sensors;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import com.shimmerresearch.driver.Configuration.CHANNEL_UNITS;
+import com.shimmerresearch.driver.Configuration.COMMUNICATION_TYPE;
+import com.shimmerresearch.driver.Configuration.Verisense.CompatibilityInfoForMaps;
+import com.shimmerresearch.driver.Configuration;
+import com.shimmerresearch.driver.ObjectCluster;
+import com.shimmerresearch.driver.ShimmerDevice;
+import com.shimmerresearch.driver.calibration.CalibDetails;
+import com.shimmerresearch.driver.calibration.CalibDetailsKinematic;
+import com.shimmerresearch.driver.calibration.UtilCalibration;
+import com.shimmerresearch.driverUtilities.ChannelDetails;
+import com.shimmerresearch.driverUtilities.ConfigOptionDetailsSensor;
+import com.shimmerresearch.driverUtilities.SensorDetails;
+import com.shimmerresearch.driverUtilities.SensorDetailsRef;
+import com.shimmerresearch.driverUtilities.SensorGroupingDetails;
+import com.shimmerresearch.driverUtilities.UtilShimmer;
+import com.shimmerresearch.driverUtilities.ChannelDetails.CHANNEL_DATA_ENDIAN;
+import com.shimmerresearch.driverUtilities.ChannelDetails.CHANNEL_DATA_TYPE;
+import com.shimmerresearch.driverUtilities.ChannelDetails.CHANNEL_TYPE;
+import com.shimmerresearch.sensors.AbstractSensor;
+import com.shimmerresearch.sensors.ActionSetting;
+
+/**
+ * Second-generation Verisense IMU: LSM6DSV (accelerometer + gyroscope) with the
+ * LIS2MDL magnetometer read via the LSM6DSV sensor hub. Used on SR68-9/10 and
+ * SR61-5/6.
+ * <p>
+ * Unlike {@link SensorLSM6DS3}, the on-device payload stores a variable-length
+ * tagged FIFO ([TAG_CNT][X][Y][Z]) interleaving the three streams; the byte-level
+ * extraction + per-stream timestamping lives in
+ * {@code VerisenseDevice.parseDataBlockDataLsm6dsv(...)}. This class provides the
+ * channel definitions, configuration and calibration. Calibration matches the
+ * firmware/SDK nominal model: value = raw / sensitivity (identity alignment,
+ * zero offset) where sensitivity = 32768/(FS*9.80665) for accel, 32768/FS for
+ * gyro and 1/0.15 for mag.
+ *
+ * @author Mark Nolan
+ */
+public class SensorLSM6DSV extends AbstractSensor {
+
+	private static final long serialVersionUID = 6336129814111379815L;
+
+	public static final String ACCEL_ID = "Accel2";
+
+	/** Same ODR setting drives accel and gyro. */
+	protected LSM6DSV_RATE rate = LSM6DSV_RATE.RATE_60_HZ;
+	protected LSM6DSV_ACCEL_RANGE rangeAccel = LSM6DSV_ACCEL_RANGE.RANGE_4G;
+	protected LSM6DSV_GYRO_RANGE rangeGyro = LSM6DSV_GYRO_RANGE.RANGE_500DPS;
+	protected LIS2MDL_RATE rateMag = LIS2MDL_RATE.RATE_15_HZ;
+
+	public static enum LSM6DSV_RATE implements ISensorConfig {
+		POWER_DOWN("Power-down", 0b0000, 0.0),
+		RATE_1_875_HZ("1.875Hz", 0b0001, 1.875),
+		RATE_7_5_HZ("7.5Hz", 0b0010, 7.5),
+		RATE_15_HZ("15.0Hz", 0b0011, 15.0),
+		RATE_30_HZ("30.0Hz", 0b0100, 30.0),
+		RATE_60_HZ("60.0Hz", 0b0101, 60.0),
+		RATE_120_HZ("120.0Hz", 0b0110, 120.0),
+		RATE_240_HZ("240.0Hz", 0b0111, 240.0),
+		RATE_480_HZ("480.0Hz", 0b1000, 480.0),
+		RATE_960_HZ("960.0Hz", 0b1001, 960.0),
+		RATE_1920_HZ("1920.0Hz", 0b1010, 1920.0),
+		RATE_3840_HZ("3840.0Hz", 0b1011, 3840.0),
+		RATE_7680_HZ("7680.0Hz", 0b1100, 7680.0);
+
+		public String label;
+		public Integer configValue;
+		public double freqHz;
+
+		public static Map<String, Integer> REF_MAP = new HashMap<>();
+		static {
+			for (LSM6DSV_RATE e : values()) { REF_MAP.put(e.label, e.configValue); }
+		}
+		static Map<Integer, LSM6DSV_RATE> BY_CONFIG_VALUE = new HashMap<>();
+		static {
+			for (LSM6DSV_RATE e : values()) { BY_CONFIG_VALUE.put(e.configValue, e); }
+		}
+
+		private LSM6DSV_RATE(String label, Integer configValue, double freqHz) {
+			this.label = label; this.configValue = configValue; this.freqHz = freqHz;
+		}
+		public static String[] getLabels() { return REF_MAP.keySet().toArray(new String[REF_MAP.keySet().size()]); }
+		public static Integer[] getConfigValues() { return REF_MAP.values().toArray(new Integer[REF_MAP.values().size()]); }
+		public static LSM6DSV_RATE getForConfigValue(int configValue) {
+			return BY_CONFIG_VALUE.get(UtilShimmer.nudgeInteger(configValue, POWER_DOWN.configValue, RATE_7680_HZ.configValue));
+		}
+	}
+
+	public static enum LSM6DSV_ACCEL_RANGE implements ISensorConfig {
+		RANGE_2G(UtilShimmer.UNICODE_PLUS_MINUS + " 2g", 0),
+		RANGE_4G(UtilShimmer.UNICODE_PLUS_MINUS + " 4g", 1),
+		RANGE_8G(UtilShimmer.UNICODE_PLUS_MINUS + " 8g", 2),
+		RANGE_16G(UtilShimmer.UNICODE_PLUS_MINUS + " 16g", 3);
+
+		String label; Integer configValue;
+		static Map<String, Integer> REF_MAP = new HashMap<>();
+		static { for (LSM6DSV_ACCEL_RANGE e : values()) { REF_MAP.put(e.label, e.configValue); } }
+		static Map<Integer, LSM6DSV_ACCEL_RANGE> BY_CONFIG_VALUE = new HashMap<>();
+		static { for (LSM6DSV_ACCEL_RANGE e : values()) { BY_CONFIG_VALUE.put(e.configValue, e); } }
+		private LSM6DSV_ACCEL_RANGE(String label, Integer configValue) { this.label = label; this.configValue = configValue; }
+		public static String[] getLabels() { return REF_MAP.keySet().toArray(new String[REF_MAP.keySet().size()]); }
+		public static Integer[] getConfigValues() { return REF_MAP.values().toArray(new Integer[REF_MAP.values().size()]); }
+		public static LSM6DSV_ACCEL_RANGE getForConfigValue(int configValue) {
+			return BY_CONFIG_VALUE.get(UtilShimmer.nudgeInteger(configValue, RANGE_2G.configValue, RANGE_16G.configValue));
+		}
+	}
+
+	public static enum LSM6DSV_GYRO_RANGE implements ISensorConfig {
+		RANGE_125DPS(UtilShimmer.UNICODE_PLUS_MINUS + " 125dps", 0),
+		RANGE_250DPS(UtilShimmer.UNICODE_PLUS_MINUS + " 250dps", 1),
+		RANGE_500DPS(UtilShimmer.UNICODE_PLUS_MINUS + " 500dps", 2),
+		RANGE_1000DPS(UtilShimmer.UNICODE_PLUS_MINUS + " 1000dps", 3),
+		RANGE_2000DPS(UtilShimmer.UNICODE_PLUS_MINUS + " 2000dps", 4);
+
+		String label; Integer configValue;
+		static Map<String, Integer> REF_MAP = new HashMap<>();
+		static { for (LSM6DSV_GYRO_RANGE e : values()) { REF_MAP.put(e.label, e.configValue); } }
+		static Map<Integer, LSM6DSV_GYRO_RANGE> BY_CONFIG_VALUE = new HashMap<>();
+		static { for (LSM6DSV_GYRO_RANGE e : values()) { BY_CONFIG_VALUE.put(e.configValue, e); } }
+		private LSM6DSV_GYRO_RANGE(String label, Integer configValue) { this.label = label; this.configValue = configValue; }
+		public static String[] getLabels() { return REF_MAP.keySet().toArray(new String[REF_MAP.keySet().size()]); }
+		public static Integer[] getConfigValues() { return REF_MAP.values().toArray(new Integer[REF_MAP.values().size()]); }
+		public static LSM6DSV_GYRO_RANGE getForConfigValue(int configValue) {
+			return BY_CONFIG_VALUE.get(UtilShimmer.nudgeInteger(configValue, RANGE_125DPS.configValue, RANGE_2000DPS.configValue));
+		}
+	}
+
+	/** Magnetometer output (sensor-hub) rate code. */
+	public static enum LIS2MDL_RATE implements ISensorConfig {
+		RATE_15_HZ("15.0Hz", 0, 15.0),
+		RATE_30_HZ("30.0Hz", 1, 30.0),
+		RATE_60_HZ("60.0Hz", 2, 60.0),
+		RATE_120_HZ("120.0Hz", 3, 120.0);
+
+		String label; Integer configValue; double freqHz;
+		static Map<String, Integer> REF_MAP = new HashMap<>();
+		static { for (LIS2MDL_RATE e : values()) { REF_MAP.put(e.label, e.configValue); } }
+		static Map<Integer, LIS2MDL_RATE> BY_CONFIG_VALUE = new HashMap<>();
+		static { for (LIS2MDL_RATE e : values()) { BY_CONFIG_VALUE.put(e.configValue, e); } }
+		private LIS2MDL_RATE(String label, Integer configValue, double freqHz) { this.label = label; this.configValue = configValue; this.freqHz = freqHz; }
+		public static String[] getLabels() { return REF_MAP.keySet().toArray(new String[REF_MAP.keySet().size()]); }
+		public static Integer[] getConfigValues() { return REF_MAP.values().toArray(new Integer[REF_MAP.values().size()]); }
+		public static LIS2MDL_RATE getForConfigValue(int configValue) {
+			return BY_CONFIG_VALUE.get(UtilShimmer.nudgeInteger(configValue, RATE_15_HZ.configValue, RATE_120_HZ.configValue));
+		}
+	}
+
+	public class GuiLabelSensors {
+		public static final String ACCEL2 = "Accelerometer2";
+		public static final String GYRO = "Gyroscope";
+		public static final String MAG = "Magnetometer";
+	}
+
+	public static class LABEL_SENSOR_TILE {
+		public static final String ACCEL2_GYRO_MAG = "ACCEL2 GYRO MAG";
+	}
+
+	public static class DatabaseChannelHandles {
+		public static final String LSM6DSV_ACC_X = "LSM6DSV_ACC_X";
+		public static final String LSM6DSV_ACC_Y = "LSM6DSV_ACC_Y";
+		public static final String LSM6DSV_ACC_Z = "LSM6DSV_ACC_Z";
+		public static final String LSM6DSV_GYRO_X = "LSM6DSV_GYRO_X";
+		public static final String LSM6DSV_GYRO_Y = "LSM6DSV_GYRO_Y";
+		public static final String LSM6DSV_GYRO_Z = "LSM6DSV_GYRO_Z";
+		public static final String LIS2MDL_MAG_X = "LIS2MDL_MAG_X";
+		public static final String LIS2MDL_MAG_Y = "LIS2MDL_MAG_Y";
+		public static final String LIS2MDL_MAG_Z = "LIS2MDL_MAG_Z";
+	}
+
+	public class GuiLabelConfig {
+		public static final String LSM6DSV_RATE = "Accel_Gyro_Rate_Gen2";
+		public static final String LSM6DSV_ACCEL_RANGE = "Accel_Range_Gen2";
+		public static final String LSM6DSV_GYRO_RANGE = "Gyro_Range_Gen2";
+		public static final String LIS2MDL_RATE = "Mag_Rate_Gen2";
+	}
+
+	public static class ObjectClusterSensorName {
+		public static String LSM6DSV_ACC_X = ACCEL_ID + "_X";
+		public static String LSM6DSV_ACC_Y = ACCEL_ID + "_Y";
+		public static String LSM6DSV_ACC_Z = ACCEL_ID + "_Z";
+		public static String LSM6DSV_GYRO_X = "Gyro_X";
+		public static String LSM6DSV_GYRO_Y = "Gyro_Y";
+		public static String LSM6DSV_GYRO_Z = "Gyro_Z";
+		public static String LIS2MDL_MAG_X = "Mag_X";
+		public static String LIS2MDL_MAG_Y = "Mag_Y";
+		public static String LIS2MDL_MAG_Z = "Mag_Z";
+	}
+
+	public static final class DatabaseConfigHandle {
+		public static final String LSM6DSV_RANGE = "LSM6DSV_Range";
+		public static final String LSM6DSV_RATE = "LSM6DSV_Rate";
+		public static final String LIS2MDL_RATE = "LIS2MDL_Rate";
+	}
+
+	public static final ConfigOptionDetailsSensor CONFIG_OPTION_ACCEL_RANGE = new ConfigOptionDetailsSensor(
+			SensorLSM6DSV.GuiLabelConfig.LSM6DSV_ACCEL_RANGE,
+			SensorLSM6DSV.DatabaseConfigHandle.LSM6DSV_RANGE,
+			LSM6DSV_ACCEL_RANGE.getLabels(), LSM6DSV_ACCEL_RANGE.getConfigValues(),
+			ConfigOptionDetailsSensor.GUI_COMPONENT_TYPE.COMBOBOX,
+			CompatibilityInfoForMaps.listOfCompatibleVersionInfoLSM6DSV);
+
+	public static final ConfigOptionDetailsSensor CONFIG_OPTION_GYRO_RANGE = new ConfigOptionDetailsSensor(
+			SensorLSM6DSV.GuiLabelConfig.LSM6DSV_GYRO_RANGE,
+			SensorLSM6DSV.DatabaseConfigHandle.LSM6DSV_RANGE,
+			LSM6DSV_GYRO_RANGE.getLabels(), LSM6DSV_GYRO_RANGE.getConfigValues(),
+			ConfigOptionDetailsSensor.GUI_COMPONENT_TYPE.COMBOBOX,
+			CompatibilityInfoForMaps.listOfCompatibleVersionInfoLSM6DSV);
+
+	public static final ConfigOptionDetailsSensor CONFIG_OPTION_RATE = new ConfigOptionDetailsSensor(
+			SensorLSM6DSV.GuiLabelConfig.LSM6DSV_RATE,
+			SensorLSM6DSV.DatabaseConfigHandle.LSM6DSV_RATE,
+			LSM6DSV_RATE.getLabels(), LSM6DSV_RATE.getConfigValues(),
+			ConfigOptionDetailsSensor.GUI_COMPONENT_TYPE.COMBOBOX,
+			CompatibilityInfoForMaps.listOfCompatibleVersionInfoLSM6DSV);
+
+	public static final ConfigOptionDetailsSensor CONFIG_OPTION_MAG_RATE = new ConfigOptionDetailsSensor(
+			SensorLSM6DSV.GuiLabelConfig.LIS2MDL_RATE,
+			SensorLSM6DSV.DatabaseConfigHandle.LIS2MDL_RATE,
+			LIS2MDL_RATE.getLabels(), LIS2MDL_RATE.getConfigValues(),
+			ConfigOptionDetailsSensor.GUI_COMPONENT_TYPE.COMBOBOX,
+			CompatibilityInfoForMaps.listOfCompatibleVersionInfoLSM6DSV);
+
+	// ----------------- Calibration Start -----------------------
+	// Identity alignment + zero offset so calibrated = raw / sensitivity, matching
+	// the firmware/SDK nominal model (and the validated standalone decoder).
+	public static final double[][] DEFAULT_OFFSET_VECTOR_LSM6DSV = {{0},{0},{0}};
+	public static final double[][] DEFAULT_ALIGNMENT_MATRIX_LSM6DSV = {{1,0,0},{0,1,0},{0,0,1}};
+
+	// Accel sensitivity (LSB per m/s^2) = 32768/(FS_g*9.80665)
+	public static final double[][] SENS_ACCEL_2G  = {{1670.703,0,0},{0,1670.703,0},{0,0,1670.703}};
+	public static final double[][] SENS_ACCEL_4G  = {{835.3517,0,0},{0,835.3517,0},{0,0,835.3517}};
+	public static final double[][] SENS_ACCEL_8G  = {{417.6759,0,0},{0,417.6759,0},{0,0,417.6759}};
+	public static final double[][] SENS_ACCEL_16G = {{208.8379,0,0},{0,208.8379,0},{0,0,208.8379}};
+
+	// Gyro sensitivity (LSB per dps) = 32768/FS_dps
+	public static final double[][] SENS_GYRO_125DPS  = {{262.144,0,0},{0,262.144,0},{0,0,262.144}};
+	public static final double[][] SENS_GYRO_250DPS  = {{131.072,0,0},{0,131.072,0},{0,0,131.072}};
+	public static final double[][] SENS_GYRO_500DPS  = {{65.536,0,0},{0,65.536,0},{0,0,65.536}};
+	public static final double[][] SENS_GYRO_1000DPS = {{32.768,0,0},{0,32.768,0},{0,0,32.768}};
+	public static final double[][] SENS_GYRO_2000DPS = {{16.384,0,0},{0,16.384,0},{0,0,16.384}};
+
+	// Mag sensitivity (LSB per uT) = 1/0.15
+	public static final double[][] SENS_MAG = {{6.666667,0,0},{0,6.666667,0},{0,0,6.666667}};
+
+	public CalibDetailsKinematic calibDetailsAccel2g = new CalibDetailsKinematic(
+			LSM6DSV_ACCEL_RANGE.RANGE_2G.configValue, LSM6DSV_ACCEL_RANGE.RANGE_2G.label,
+			DEFAULT_ALIGNMENT_MATRIX_LSM6DSV, SENS_ACCEL_2G, DEFAULT_OFFSET_VECTOR_LSM6DSV);
+	public CalibDetailsKinematic calibDetailsAccel4g = new CalibDetailsKinematic(
+			LSM6DSV_ACCEL_RANGE.RANGE_4G.configValue, LSM6DSV_ACCEL_RANGE.RANGE_4G.label,
+			DEFAULT_ALIGNMENT_MATRIX_LSM6DSV, SENS_ACCEL_4G, DEFAULT_OFFSET_VECTOR_LSM6DSV);
+	public CalibDetailsKinematic calibDetailsAccel8g = new CalibDetailsKinematic(
+			LSM6DSV_ACCEL_RANGE.RANGE_8G.configValue, LSM6DSV_ACCEL_RANGE.RANGE_8G.label,
+			DEFAULT_ALIGNMENT_MATRIX_LSM6DSV, SENS_ACCEL_8G, DEFAULT_OFFSET_VECTOR_LSM6DSV);
+	public CalibDetailsKinematic calibDetailsAccel16g = new CalibDetailsKinematic(
+			LSM6DSV_ACCEL_RANGE.RANGE_16G.configValue, LSM6DSV_ACCEL_RANGE.RANGE_16G.label,
+			DEFAULT_ALIGNMENT_MATRIX_LSM6DSV, SENS_ACCEL_16G, DEFAULT_OFFSET_VECTOR_LSM6DSV);
+
+	public CalibDetailsKinematic calibDetailsGyro125dps = new CalibDetailsKinematic(
+			LSM6DSV_GYRO_RANGE.RANGE_125DPS.configValue, LSM6DSV_GYRO_RANGE.RANGE_125DPS.label,
+			DEFAULT_ALIGNMENT_MATRIX_LSM6DSV, SENS_GYRO_125DPS, DEFAULT_OFFSET_VECTOR_LSM6DSV);
+	public CalibDetailsKinematic calibDetailsGyro250dps = new CalibDetailsKinematic(
+			LSM6DSV_GYRO_RANGE.RANGE_250DPS.configValue, LSM6DSV_GYRO_RANGE.RANGE_250DPS.label,
+			DEFAULT_ALIGNMENT_MATRIX_LSM6DSV, SENS_GYRO_250DPS, DEFAULT_OFFSET_VECTOR_LSM6DSV);
+	public CalibDetailsKinematic calibDetailsGyro500dps = new CalibDetailsKinematic(
+			LSM6DSV_GYRO_RANGE.RANGE_500DPS.configValue, LSM6DSV_GYRO_RANGE.RANGE_500DPS.label,
+			DEFAULT_ALIGNMENT_MATRIX_LSM6DSV, SENS_GYRO_500DPS, DEFAULT_OFFSET_VECTOR_LSM6DSV);
+	public CalibDetailsKinematic calibDetailsGyro1000dps = new CalibDetailsKinematic(
+			LSM6DSV_GYRO_RANGE.RANGE_1000DPS.configValue, LSM6DSV_GYRO_RANGE.RANGE_1000DPS.label,
+			DEFAULT_ALIGNMENT_MATRIX_LSM6DSV, SENS_GYRO_1000DPS, DEFAULT_OFFSET_VECTOR_LSM6DSV);
+	public CalibDetailsKinematic calibDetailsGyro2000dps = new CalibDetailsKinematic(
+			LSM6DSV_GYRO_RANGE.RANGE_2000DPS.configValue, LSM6DSV_GYRO_RANGE.RANGE_2000DPS.label,
+			DEFAULT_ALIGNMENT_MATRIX_LSM6DSV, SENS_GYRO_2000DPS, DEFAULT_OFFSET_VECTOR_LSM6DSV);
+
+	public CalibDetailsKinematic calibDetailsMag = new CalibDetailsKinematic(
+			0, "Default", DEFAULT_ALIGNMENT_MATRIX_LSM6DSV, SENS_MAG, DEFAULT_OFFSET_VECTOR_LSM6DSV);
+
+	public CalibDetailsKinematic mCurrentCalibDetailsAccel = calibDetailsAccel4g;
+	public CalibDetailsKinematic mCurrentCalibDetailsGyro = calibDetailsGyro500dps;
+	public CalibDetailsKinematic mCurrentCalibDetailsMag = calibDetailsMag;
+	// ----------------- Calibration end -----------------------
+
+	//--------- Sensor info start --------------
+	public static final SensorDetailsRef SENSOR_LSM6DSV_ACCEL = new SensorDetailsRef(
+			Configuration.Verisense.SensorBitmap.LSM6DSV_ACCEL,
+			Configuration.Verisense.SensorBitmap.LSM6DSV_ACCEL,
+			GuiLabelSensors.ACCEL2,
+			CompatibilityInfoForMaps.listOfCompatibleVersionInfoLSM6DSV,
+			Arrays.asList(Configuration.Verisense.SENSOR_ID.LSM6DSV_ACCEL),
+			Arrays.asList(GuiLabelConfig.LSM6DSV_ACCEL_RANGE, GuiLabelConfig.LSM6DSV_GYRO_RANGE, GuiLabelConfig.LSM6DSV_RATE),
+			Arrays.asList(ObjectClusterSensorName.LSM6DSV_ACC_X, ObjectClusterSensorName.LSM6DSV_ACC_Y, ObjectClusterSensorName.LSM6DSV_ACC_Z),
+			false);
+
+	public static final SensorDetailsRef SENSOR_LSM6DSV_GYRO = new SensorDetailsRef(
+			Configuration.Verisense.SensorBitmap.LSM6DSV_GYRO,
+			Configuration.Verisense.SensorBitmap.LSM6DSV_GYRO,
+			GuiLabelSensors.GYRO,
+			CompatibilityInfoForMaps.listOfCompatibleVersionInfoLSM6DSV,
+			Arrays.asList(Configuration.Verisense.SENSOR_ID.LSM6DSV_GYRO),
+			Arrays.asList(GuiLabelConfig.LSM6DSV_ACCEL_RANGE, GuiLabelConfig.LSM6DSV_GYRO_RANGE, GuiLabelConfig.LSM6DSV_RATE),
+			Arrays.asList(ObjectClusterSensorName.LSM6DSV_GYRO_X, ObjectClusterSensorName.LSM6DSV_GYRO_Y, ObjectClusterSensorName.LSM6DSV_GYRO_Z),
+			false);
+
+	public static final SensorDetailsRef SENSOR_LIS2MDL_MAG = new SensorDetailsRef(
+			Configuration.Verisense.SensorBitmap.LSM6DSV_MAG,
+			Configuration.Verisense.SensorBitmap.LSM6DSV_MAG,
+			GuiLabelSensors.MAG,
+			CompatibilityInfoForMaps.listOfCompatibleVersionInfoLSM6DSV,
+			Arrays.asList(Configuration.Verisense.SENSOR_ID.LSM6DSV_MAG),
+			Arrays.asList(GuiLabelConfig.LIS2MDL_RATE),
+			Arrays.asList(ObjectClusterSensorName.LIS2MDL_MAG_X, ObjectClusterSensorName.LIS2MDL_MAG_Y, ObjectClusterSensorName.LIS2MDL_MAG_Z),
+			false);
+
+	public static final Map<Integer, SensorDetailsRef> SENSOR_MAP_REF;
+	static {
+		Map<Integer, SensorDetailsRef> aMap = new LinkedHashMap<Integer, SensorDetailsRef>();
+		aMap.put(Configuration.Verisense.SENSOR_ID.LSM6DSV_ACCEL, SensorLSM6DSV.SENSOR_LSM6DSV_ACCEL);
+		aMap.put(Configuration.Verisense.SENSOR_ID.LSM6DSV_GYRO, SensorLSM6DSV.SENSOR_LSM6DSV_GYRO);
+		aMap.put(Configuration.Verisense.SENSOR_ID.LSM6DSV_MAG, SensorLSM6DSV.SENSOR_LIS2MDL_MAG);
+		SENSOR_MAP_REF = Collections.unmodifiableMap(aMap);
+	}
+	//--------- Sensor info end --------------
+
+	//--------- Channel info start --------------
+	public static final ChannelDetails CHANNEL_LSM6DSV_ACCEL_X = new ChannelDetails(
+			ObjectClusterSensorName.LSM6DSV_ACC_X, ObjectClusterSensorName.LSM6DSV_ACC_X, DatabaseChannelHandles.LSM6DSV_ACC_X,
+			CHANNEL_DATA_TYPE.INT16, 2, CHANNEL_DATA_ENDIAN.LSB, CHANNEL_UNITS.METER_PER_SECOND_SQUARE,
+			Arrays.asList(CHANNEL_TYPE.UNCAL, CHANNEL_TYPE.CAL, CHANNEL_TYPE.DERIVED));
+	public static final ChannelDetails CHANNEL_LSM6DSV_ACCEL_Y = new ChannelDetails(
+			ObjectClusterSensorName.LSM6DSV_ACC_Y, ObjectClusterSensorName.LSM6DSV_ACC_Y, DatabaseChannelHandles.LSM6DSV_ACC_Y,
+			CHANNEL_DATA_TYPE.INT16, 2, CHANNEL_DATA_ENDIAN.LSB, CHANNEL_UNITS.METER_PER_SECOND_SQUARE,
+			Arrays.asList(CHANNEL_TYPE.UNCAL, CHANNEL_TYPE.CAL, CHANNEL_TYPE.DERIVED));
+	public static final ChannelDetails CHANNEL_LSM6DSV_ACCEL_Z = new ChannelDetails(
+			ObjectClusterSensorName.LSM6DSV_ACC_Z, ObjectClusterSensorName.LSM6DSV_ACC_Z, DatabaseChannelHandles.LSM6DSV_ACC_Z,
+			CHANNEL_DATA_TYPE.INT16, 2, CHANNEL_DATA_ENDIAN.LSB, CHANNEL_UNITS.METER_PER_SECOND_SQUARE,
+			Arrays.asList(CHANNEL_TYPE.UNCAL, CHANNEL_TYPE.CAL, CHANNEL_TYPE.DERIVED));
+
+	public static final ChannelDetails CHANNEL_LSM6DSV_GYRO_X = new ChannelDetails(
+			ObjectClusterSensorName.LSM6DSV_GYRO_X, ObjectClusterSensorName.LSM6DSV_GYRO_X, DatabaseChannelHandles.LSM6DSV_GYRO_X,
+			CHANNEL_DATA_TYPE.INT16, 2, CHANNEL_DATA_ENDIAN.LSB, CHANNEL_UNITS.DEGREES_PER_SECOND,
+			Arrays.asList(CHANNEL_TYPE.UNCAL, CHANNEL_TYPE.CAL, CHANNEL_TYPE.DERIVED));
+	public static final ChannelDetails CHANNEL_LSM6DSV_GYRO_Y = new ChannelDetails(
+			ObjectClusterSensorName.LSM6DSV_GYRO_Y, ObjectClusterSensorName.LSM6DSV_GYRO_Y, DatabaseChannelHandles.LSM6DSV_GYRO_Y,
+			CHANNEL_DATA_TYPE.INT16, 2, CHANNEL_DATA_ENDIAN.LSB, CHANNEL_UNITS.DEGREES_PER_SECOND,
+			Arrays.asList(CHANNEL_TYPE.UNCAL, CHANNEL_TYPE.CAL, CHANNEL_TYPE.DERIVED));
+	public static final ChannelDetails CHANNEL_LSM6DSV_GYRO_Z = new ChannelDetails(
+			ObjectClusterSensorName.LSM6DSV_GYRO_Z, ObjectClusterSensorName.LSM6DSV_GYRO_Z, DatabaseChannelHandles.LSM6DSV_GYRO_Z,
+			CHANNEL_DATA_TYPE.INT16, 2, CHANNEL_DATA_ENDIAN.LSB, CHANNEL_UNITS.DEGREES_PER_SECOND,
+			Arrays.asList(CHANNEL_TYPE.UNCAL, CHANNEL_TYPE.CAL, CHANNEL_TYPE.DERIVED));
+
+	public static final ChannelDetails CHANNEL_LIS2MDL_MAG_X = new ChannelDetails(
+			ObjectClusterSensorName.LIS2MDL_MAG_X, ObjectClusterSensorName.LIS2MDL_MAG_X, DatabaseChannelHandles.LIS2MDL_MAG_X,
+			CHANNEL_DATA_TYPE.INT16, 2, CHANNEL_DATA_ENDIAN.LSB, CHANNEL_UNITS.LOCAL_FLUX,
+			Arrays.asList(CHANNEL_TYPE.UNCAL, CHANNEL_TYPE.CAL, CHANNEL_TYPE.DERIVED));
+	public static final ChannelDetails CHANNEL_LIS2MDL_MAG_Y = new ChannelDetails(
+			ObjectClusterSensorName.LIS2MDL_MAG_Y, ObjectClusterSensorName.LIS2MDL_MAG_Y, DatabaseChannelHandles.LIS2MDL_MAG_Y,
+			CHANNEL_DATA_TYPE.INT16, 2, CHANNEL_DATA_ENDIAN.LSB, CHANNEL_UNITS.LOCAL_FLUX,
+			Arrays.asList(CHANNEL_TYPE.UNCAL, CHANNEL_TYPE.CAL, CHANNEL_TYPE.DERIVED));
+	public static final ChannelDetails CHANNEL_LIS2MDL_MAG_Z = new ChannelDetails(
+			ObjectClusterSensorName.LIS2MDL_MAG_Z, ObjectClusterSensorName.LIS2MDL_MAG_Z, DatabaseChannelHandles.LIS2MDL_MAG_Z,
+			CHANNEL_DATA_TYPE.INT16, 2, CHANNEL_DATA_ENDIAN.LSB, CHANNEL_UNITS.LOCAL_FLUX,
+			Arrays.asList(CHANNEL_TYPE.UNCAL, CHANNEL_TYPE.CAL, CHANNEL_TYPE.DERIVED));
+
+	public static final Map<String, ChannelDetails> CHANNEL_MAP_REF;
+	static {
+		Map<String, ChannelDetails> aMap = new LinkedHashMap<String, ChannelDetails>();
+		aMap.put(ObjectClusterSensorName.LSM6DSV_ACC_X, CHANNEL_LSM6DSV_ACCEL_X);
+		aMap.put(ObjectClusterSensorName.LSM6DSV_ACC_Y, CHANNEL_LSM6DSV_ACCEL_Y);
+		aMap.put(ObjectClusterSensorName.LSM6DSV_ACC_Z, CHANNEL_LSM6DSV_ACCEL_Z);
+		aMap.put(ObjectClusterSensorName.LSM6DSV_GYRO_X, CHANNEL_LSM6DSV_GYRO_X);
+		aMap.put(ObjectClusterSensorName.LSM6DSV_GYRO_Y, CHANNEL_LSM6DSV_GYRO_Y);
+		aMap.put(ObjectClusterSensorName.LSM6DSV_GYRO_Z, CHANNEL_LSM6DSV_GYRO_Z);
+		aMap.put(ObjectClusterSensorName.LIS2MDL_MAG_X, CHANNEL_LIS2MDL_MAG_X);
+		aMap.put(ObjectClusterSensorName.LIS2MDL_MAG_Y, CHANNEL_LIS2MDL_MAG_Y);
+		aMap.put(ObjectClusterSensorName.LIS2MDL_MAG_Z, CHANNEL_LIS2MDL_MAG_Z);
+		CHANNEL_MAP_REF = Collections.unmodifiableMap(aMap);
+	}
+	//--------- Channel info end --------------
+
+	public SensorLSM6DSV(ShimmerDevice shimmerDevice) {
+		super(SENSORS.LSM6DSV, shimmerDevice);
+		initialise();
+	}
+
+	@Override
+	public void generateSensorMap() {
+		super.createLocalSensorMapWithCustomParser(SENSOR_MAP_REF, CHANNEL_MAP_REF);
+	}
+
+	@Override
+	public void generateConfigOptionsMap() {
+		mConfigOptionsMap.clear();
+		addConfigOption(CONFIG_OPTION_ACCEL_RANGE);
+		addConfigOption(CONFIG_OPTION_GYRO_RANGE);
+		addConfigOption(CONFIG_OPTION_RATE);
+		addConfigOption(CONFIG_OPTION_MAG_RATE);
+	}
+
+	@Override
+	public void generateSensorGroupMapping() {
+		int groupIndex = Configuration.Verisense.LABEL_SENSOR_TILE.ACCEL2_GYRO.ordinal();
+		if(mShimmerVerObject.isShimmerGenVerisense()) {
+			mSensorGroupingMap.put(groupIndex, new SensorGroupingDetails(
+					LABEL_SENSOR_TILE.ACCEL2_GYRO_MAG,
+					Arrays.asList(
+							Configuration.Verisense.SENSOR_ID.LSM6DSV_GYRO,
+							Configuration.Verisense.SENSOR_ID.LSM6DSV_ACCEL,
+							Configuration.Verisense.SENSOR_ID.LSM6DSV_MAG),
+					CompatibilityInfoForMaps.listOfCompatibleVersionInfoLSM6DSV));
+		}
+		super.updateSensorGroupingMap();
+	}
+
+	@Override
+	public ObjectCluster processDataCustom(SensorDetails sensorDetails, byte[] rawData, COMMUNICATION_TYPE commType, ObjectCluster objectCluster, boolean isTimeSyncEnabled, double pcTimestampMs) {
+		String guiLabel = sensorDetails.mSensorDetailsRef.mGuiFriendlyLabel;
+		if(guiLabel.equals(GuiLabelSensors.ACCEL2) && mCurrentCalibDetailsAccel!=null) {
+			objectCluster = sensorDetails.processDataCommon(rawData, commType, objectCluster, isTimeSyncEnabled, pcTimestampMs);
+			calibrateXyz(objectCluster, mCurrentCalibDetailsAccel, CHANNEL_LSM6DSV_ACCEL_X, CHANNEL_LSM6DSV_ACCEL_Y, CHANNEL_LSM6DSV_ACCEL_Z, false);
+		} else if(guiLabel.equals(GuiLabelSensors.GYRO) && mCurrentCalibDetailsGyro!=null) {
+			objectCluster = sensorDetails.processDataCommon(rawData, commType, objectCluster, isTimeSyncEnabled, pcTimestampMs);
+			calibrateXyz(objectCluster, mCurrentCalibDetailsGyro, CHANNEL_LSM6DSV_GYRO_X, CHANNEL_LSM6DSV_GYRO_Y, CHANNEL_LSM6DSV_GYRO_Z, true);
+		} else if(guiLabel.equals(GuiLabelSensors.MAG) && mCurrentCalibDetailsMag!=null) {
+			objectCluster = sensorDetails.processDataCommon(rawData, commType, objectCluster, isTimeSyncEnabled, pcTimestampMs);
+			calibrateXyz(objectCluster, mCurrentCalibDetailsMag, CHANNEL_LIS2MDL_MAG_X, CHANNEL_LIS2MDL_MAG_Y, CHANNEL_LIS2MDL_MAG_Z, true);
+		}
+		return objectCluster;
+	}
+
+	/**
+	 * Adds default-calibrated (CAL) data. When {@code addDerived} is true also adds
+	 * a DERIVED copy - mirrors the gen-1 LSM6DS3 behaviour where gyro/mag emit a
+	 * DERIVED ("_CAL") output file while accel emits the default-cal file.
+	 */
+	private void calibrateXyz(ObjectCluster objectCluster, CalibDetailsKinematic calibDetails, ChannelDetails chX, ChannelDetails chY, ChannelDetails chZ, boolean addDerived) {
+		double[] unCal = new double[3];
+		unCal[0] = objectCluster.getFormatClusterValue(chX, CHANNEL_TYPE.UNCAL);
+		unCal[1] = objectCluster.getFormatClusterValue(chY, CHANNEL_TYPE.UNCAL);
+		unCal[2] = objectCluster.getFormatClusterValue(chZ, CHANNEL_TYPE.UNCAL);
+		double[] cal = UtilCalibration.calibrateInertialSensorData(unCal, calibDetails.getDefaultMatrixMultipliedInverseAMSM(), calibDetails.getDefaultOffsetVector());
+		objectCluster.addCalData(chX, cal[0], objectCluster.getIndexKeeper()-3);
+		objectCluster.addCalData(chY, cal[1], objectCluster.getIndexKeeper()-2);
+		objectCluster.addCalData(chZ, cal[2], objectCluster.getIndexKeeper()-1);
+		if(addDerived) {
+			objectCluster.addData(chX.mObjectClusterName, CHANNEL_TYPE.DERIVED, chX.mDefaultCalUnits, cal[0], objectCluster.getIndexKeeper()-3, false);
+			objectCluster.addData(chY.mObjectClusterName, CHANNEL_TYPE.DERIVED, chY.mDefaultCalUnits, cal[1], objectCluster.getIndexKeeper()-2, false);
+			objectCluster.addData(chZ.mObjectClusterName, CHANNEL_TYPE.DERIVED, chZ.mDefaultCalUnits, cal[2], objectCluster.getIndexKeeper()-1, false);
+		}
+	}
+
+	@Override
+	public void checkShimmerConfigBeforeConfiguring() {
+		// no-op
+	}
+
+	@Override
+	public void configBytesGenerate(ShimmerDevice shimmerDevice, byte[] configBytes, COMMUNICATION_TYPE commType) {
+		// TODO config-write support (streaming/op-config) to be added with the gen-2 config UI.
+	}
+
+	@Override
+	public void configBytesParse(ShimmerDevice shimmerDevice, byte[] configBytes, COMMUNICATION_TYPE commType) {
+		if(isAnyChannelEnabled()) {
+			if(commType == COMMUNICATION_TYPE.SD) {
+				// Payload header bytes 18..20 (LSM6DSV_CFG_0..2). PAYLOAD_CONFIG_BYTE_INDEX is
+				// relative to the config region (rel 14/15/16 = abs 18/19/20).
+				int cfg0 = configBytes[com.shimmerresearch.verisense.payloaddesign.AsmBinaryFileConstants.PAYLOAD_CONFIG_BYTE_INDEX.PAYLOAD_CONFIG3] & 0xFF;
+				int cfg1 = configBytes[com.shimmerresearch.verisense.payloaddesign.AsmBinaryFileConstants.PAYLOAD_CONFIG_BYTE_INDEX.PAYLOAD_CONFIG4] & 0xFF;
+				int cfg2 = configBytes[com.shimmerresearch.verisense.payloaddesign.AsmBinaryFileConstants.PAYLOAD_CONFIG_BYTE_INDEX.PAYLOAD_CONFIG5] & 0xFF;
+				// Accel and gyro share the LSM6DSV ODR. Whichever is enabled carries the
+				// rate; the disabled one's ODR field is 0 (power-down), so take the non-zero.
+				int accelOdr = cfg0 & 0x0F;
+				int gyroOdr = cfg1 & 0x0F;
+				setRateConfigValue(accelOdr != 0 ? accelOdr : gyroOdr);
+				setAccelRangeConfigValue((cfg0 >> 4) & 0x03);
+				setGyroRangeConfigValue((cfg1 >> 4) & 0x0F);
+				setMagRateConfigValue(cfg2 & 0x03);
+			}
+		}
+	}
+
+	private boolean isAnyChannelEnabled() {
+		return isSensorEnabled(Configuration.Verisense.SENSOR_ID.LSM6DSV_ACCEL)
+				|| isSensorEnabled(Configuration.Verisense.SENSOR_ID.LSM6DSV_GYRO)
+				|| isSensorEnabled(Configuration.Verisense.SENSOR_ID.LSM6DSV_MAG);
+	}
+
+	@Override
+	public Object setConfigValueUsingConfigLabel(Integer sensorId, String configLabel, Object valueToSet) {
+		Object returnValue = null;
+		switch(configLabel) {
+			case(GuiLabelConfig.LSM6DSV_RATE): setRateConfigValue((int)valueToSet); break;
+			case(GuiLabelConfig.LSM6DSV_ACCEL_RANGE): setAccelRangeConfigValue((int)valueToSet); break;
+			case(GuiLabelConfig.LSM6DSV_GYRO_RANGE): setGyroRangeConfigValue((int)valueToSet); break;
+			case(GuiLabelConfig.LIS2MDL_RATE): setMagRateConfigValue((int)valueToSet); break;
+			default: returnValue = super.setConfigValueUsingConfigLabelCommon(sensorId, configLabel, valueToSet); break;
+		}
+		return returnValue;
+	}
+
+	@Override
+	public Object getConfigValueUsingConfigLabel(Integer sensorId, String configLabel) {
+		Object returnValue = null;
+		switch(configLabel) {
+			case(GuiLabelConfig.LSM6DSV_RATE): returnValue = getRateConfigValue(); break;
+			case(GuiLabelConfig.LSM6DSV_ACCEL_RANGE): returnValue = getAccelRangeConfigValue(); break;
+			case(GuiLabelConfig.LSM6DSV_GYRO_RANGE): returnValue = getGyroRangeConfigValue(); break;
+			case(GuiLabelConfig.LIS2MDL_RATE): returnValue = getMagRateConfigValue(); break;
+			case(GuiLabelConfigCommon.CALIBRATION_CURRENT_PER_SENSOR):
+				if(sensorId==Configuration.Verisense.SENSOR_ID.LSM6DSV_GYRO) { returnValue = mCurrentCalibDetailsGyro; }
+				else if(sensorId==Configuration.Verisense.SENSOR_ID.LSM6DSV_ACCEL) { returnValue = mCurrentCalibDetailsAccel; }
+				else if(sensorId==Configuration.Verisense.SENSOR_ID.LSM6DSV_MAG) { returnValue = mCurrentCalibDetailsMag; }
+				break;
+			case(GuiLabelConfigCommon.RATE): returnValue = getRateFreq(); break;
+			default: returnValue = super.getConfigValueUsingConfigLabelCommon(sensorId, configLabel); break;
+		}
+		return returnValue;
+	}
+
+	@Override
+	public void setSensorSamplingRate(double samplingRateHz) {
+		if(samplingRateHz==0) {
+			setRate(LSM6DSV_RATE.POWER_DOWN);
+		} else {
+			LSM6DSV_RATE chosen = LSM6DSV_RATE.POWER_DOWN;
+			for(LSM6DSV_RATE r : LSM6DSV_RATE.values()) {
+				if(r==LSM6DSV_RATE.POWER_DOWN) { continue; }
+				chosen = r;
+				if(r.freqHz>=samplingRateHz) { break; }
+			}
+			setRate(chosen);
+		}
+	}
+
+	public double getRateFreq() {
+		return rate.freqHz;
+	}
+
+	public void setRate(LSM6DSV_RATE rate) { this.rate = rate; }
+	public int getRateConfigValue() { return rate.configValue; }
+	public void setRateConfigValue(int configValue) { setRate(LSM6DSV_RATE.getForConfigValue(configValue)); }
+
+	public int getAccelRangeConfigValue() { return rangeAccel.configValue; }
+	public void setAccelRangeConfigValue(int configValue) {
+		rangeAccel = LSM6DSV_ACCEL_RANGE.getForConfigValue(configValue);
+		updateCurrentAccelCalibInUse();
+	}
+	public int getGyroRangeConfigValue() { return rangeGyro.configValue; }
+	public void setGyroRangeConfigValue(int configValue) {
+		rangeGyro = LSM6DSV_GYRO_RANGE.getForConfigValue(configValue);
+		updateCurrentGyroCalibInUse();
+	}
+	public int getMagRateConfigValue() { return rateMag.configValue; }
+	public void setMagRateConfigValue(int configValue) { rateMag = LIS2MDL_RATE.getForConfigValue(configValue); }
+
+	public double getMagRateFreq() { return rateMag.freqHz; }
+
+	public String getAccelRangeString() { return rangeAccel.label; }
+	public String getGyroRangeString() { return rangeGyro.label; }
+	public String getMagRateString() { return rateMag.label; }
+
+	@Override
+	public void generateCalibMap() {
+		super.generateCalibMap();
+		TreeMap<Integer, CalibDetails> calibMapAccel = new TreeMap<Integer, CalibDetails>();
+		calibMapAccel.put(calibDetailsAccel2g.mRangeValue, calibDetailsAccel2g);
+		calibMapAccel.put(calibDetailsAccel4g.mRangeValue, calibDetailsAccel4g);
+		calibMapAccel.put(calibDetailsAccel8g.mRangeValue, calibDetailsAccel8g);
+		calibMapAccel.put(calibDetailsAccel16g.mRangeValue, calibDetailsAccel16g);
+		setCalibrationMapPerSensor(Configuration.Verisense.SENSOR_ID.LSM6DSV_ACCEL, calibMapAccel);
+
+		TreeMap<Integer, CalibDetails> calibMapGyro = new TreeMap<Integer, CalibDetails>();
+		calibMapGyro.put(calibDetailsGyro125dps.mRangeValue, calibDetailsGyro125dps);
+		calibMapGyro.put(calibDetailsGyro250dps.mRangeValue, calibDetailsGyro250dps);
+		calibMapGyro.put(calibDetailsGyro500dps.mRangeValue, calibDetailsGyro500dps);
+		calibMapGyro.put(calibDetailsGyro1000dps.mRangeValue, calibDetailsGyro1000dps);
+		calibMapGyro.put(calibDetailsGyro2000dps.mRangeValue, calibDetailsGyro2000dps);
+		setCalibrationMapPerSensor(Configuration.Verisense.SENSOR_ID.LSM6DSV_GYRO, calibMapGyro);
+
+		TreeMap<Integer, CalibDetails> calibMapMag = new TreeMap<Integer, CalibDetails>();
+		calibMapMag.put(calibDetailsMag.mRangeValue, calibDetailsMag);
+		setCalibrationMapPerSensor(Configuration.Verisense.SENSOR_ID.LSM6DSV_MAG, calibMapMag);
+
+		updateCurrentAccelCalibInUse();
+		updateCurrentGyroCalibInUse();
+		updateCurrentMagCalibInUse();
+	}
+
+	public void updateCurrentAccelCalibInUse() {
+		mCurrentCalibDetailsAccel = getCurrentCalibDetailsIfKinematic(Configuration.Verisense.SENSOR_ID.LSM6DSV_ACCEL, getAccelRangeConfigValue());
+	}
+	public void updateCurrentGyroCalibInUse() {
+		mCurrentCalibDetailsGyro = getCurrentCalibDetailsIfKinematic(Configuration.Verisense.SENSOR_ID.LSM6DSV_GYRO, getGyroRangeConfigValue());
+	}
+	public void updateCurrentMagCalibInUse() {
+		mCurrentCalibDetailsMag = getCurrentCalibDetailsIfKinematic(Configuration.Verisense.SENSOR_ID.LSM6DSV_MAG, 0);
+	}
+
+	public CalibDetailsKinematic getCurrentCalibDetailsIfKinematic(int sensorId, int range) {
+		CalibDetails calibDetails = getCalibForSensor(sensorId, range);
+		if(calibDetails instanceof CalibDetailsKinematic) {
+			return (CalibDetailsKinematic) calibDetails;
+		}
+		return null;
+	}
+
+	@Override
+	public void parseConfigMap(LinkedHashMap<String, Object> mapOfConfigPerShimmer) {
+		// TODO Auto-generated method stub
+	}
+
+	@Override
+	public LinkedHashMap<String, Object> generateConfigMap() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public ActionSetting setSettings(String componentName, Object valueToSet, COMMUNICATION_TYPE commType) {
+		return null;
+	}
+
+	@Override
+	public Object getSettings(String componentName, COMMUNICATION_TYPE commType) {
+		return null;
+	}
+
+	@Override
+	public boolean setDefaultConfigForSensor(int sensorId, boolean isSensorEnabled) {
+		return false;
+	}
+
+	@Override
+	public boolean checkConfigOptionValues(String stringKey) {
+		return true;
+	}
+
+	@Override
+	public boolean processResponse(int responseCommand, Object parsedResponse, COMMUNICATION_TYPE commType) {
+		return false;
+	}
+
+}

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/sensors/SensorLSM6DSV.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/sensors/SensorLSM6DSV.java
@@ -297,7 +297,8 @@ public class SensorLSM6DSV extends AbstractSensor {
 			Configuration.Verisense.SensorBitmap.LSM6DSV_ACCEL,
 			GuiLabelSensors.ACCEL2,
 			CompatibilityInfoForMaps.listOfCompatibleVersionInfoLSM6DSV,
-			Arrays.asList(Configuration.Verisense.SENSOR_ID.LSM6DSV_ACCEL),
+			// listOfSensorIdsConflicting - none (gen-1 convention, e.g. SENSOR_GSR_VERISENSE)
+			new java.util.ArrayList<Integer>(),
 			Arrays.asList(GuiLabelConfig.LSM6DSV_ACCEL_RANGE, GuiLabelConfig.LSM6DSV_GYRO_RANGE, GuiLabelConfig.LSM6DSV_RATE),
 			Arrays.asList(ObjectClusterSensorName.LSM6DSV_ACC_X, ObjectClusterSensorName.LSM6DSV_ACC_Y, ObjectClusterSensorName.LSM6DSV_ACC_Z),
 			false);
@@ -307,7 +308,8 @@ public class SensorLSM6DSV extends AbstractSensor {
 			Configuration.Verisense.SensorBitmap.LSM6DSV_GYRO,
 			GuiLabelSensors.GYRO,
 			CompatibilityInfoForMaps.listOfCompatibleVersionInfoLSM6DSV,
-			Arrays.asList(Configuration.Verisense.SENSOR_ID.LSM6DSV_GYRO),
+			// listOfSensorIdsConflicting - none (gen-1 convention, e.g. SENSOR_GSR_VERISENSE)
+			new java.util.ArrayList<Integer>(),
 			Arrays.asList(GuiLabelConfig.LSM6DSV_ACCEL_RANGE, GuiLabelConfig.LSM6DSV_GYRO_RANGE, GuiLabelConfig.LSM6DSV_RATE),
 			Arrays.asList(ObjectClusterSensorName.LSM6DSV_GYRO_X, ObjectClusterSensorName.LSM6DSV_GYRO_Y, ObjectClusterSensorName.LSM6DSV_GYRO_Z),
 			false);
@@ -317,7 +319,8 @@ public class SensorLSM6DSV extends AbstractSensor {
 			Configuration.Verisense.SensorBitmap.LSM6DSV_MAG,
 			GuiLabelSensors.MAG,
 			CompatibilityInfoForMaps.listOfCompatibleVersionInfoLSM6DSV,
-			Arrays.asList(Configuration.Verisense.SENSOR_ID.LSM6DSV_MAG),
+			// listOfSensorIdsConflicting - none (gen-1 convention, e.g. SENSOR_GSR_VERISENSE)
+			new java.util.ArrayList<Integer>(),
 			Arrays.asList(GuiLabelConfig.LIS2MDL_RATE),
 			Arrays.asList(ObjectClusterSensorName.LIS2MDL_MAG_X, ObjectClusterSensorName.LIS2MDL_MAG_Y, ObjectClusterSensorName.LIS2MDL_MAG_Z),
 			false);

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/sensors/SensorMLX90632.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/sensors/SensorMLX90632.java
@@ -78,7 +78,8 @@ public class SensorMLX90632 extends AbstractSensor {
 			Configuration.Verisense.SensorBitmap.MLX90632,
 			GuiLabelSensors.SKIN_TEMP,
 			CompatibilityInfoForMaps.listOfCompatibleVersionInfoLSM6DSV,
-			Arrays.asList(Configuration.Verisense.SENSOR_ID.MLX90632),
+			// listOfSensorIdsConflicting - none (gen-1 convention, e.g. SENSOR_GSR_VERISENSE)
+			new java.util.ArrayList<Integer>(),
 			Arrays.asList(),
 			Arrays.asList(ObjectClusterSensorName.SKIN_TEMP_OBJECT,
 					ObjectClusterSensorName.SKIN_TEMP_AMBIENT),

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/sensors/SensorMLX90632.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/sensors/SensorMLX90632.java
@@ -1,0 +1,241 @@
+package com.shimmerresearch.verisense.sensors;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.shimmerresearch.driver.Configuration;
+import com.shimmerresearch.driver.Configuration.CHANNEL_UNITS;
+import com.shimmerresearch.driver.Configuration.COMMUNICATION_TYPE;
+import com.shimmerresearch.driver.Configuration.Verisense.CompatibilityInfoForMaps;
+import com.shimmerresearch.driver.ObjectCluster;
+import com.shimmerresearch.driver.ShimmerDevice;
+import com.shimmerresearch.driverUtilities.ChannelDetails;
+import com.shimmerresearch.driverUtilities.ChannelDetails.CHANNEL_DATA_ENDIAN;
+import com.shimmerresearch.driverUtilities.ChannelDetails.CHANNEL_DATA_TYPE;
+import com.shimmerresearch.driverUtilities.ChannelDetails.CHANNEL_TYPE;
+import com.shimmerresearch.driverUtilities.SensorDetails;
+import com.shimmerresearch.driverUtilities.SensorDetailsRef;
+import com.shimmerresearch.sensors.AbstractSensor;
+import com.shimmerresearch.verisense.payloaddesign.AsmBinaryFileConstants.PAYLOAD_CONFIG_BYTE_INDEX;
+
+/**
+ * Decoder for the MLX90632 skin temperature sensor (Verisense data-block sensor
+ * id = 9, second-generation hardware). Data block = N samples x 4 bytes:
+ * object (skin/target) int16 then ambient int16, both little-endian
+ * centi-degrees Celsius (the firmware applies the chip's EEPROM calibration
+ * before quantising, so the host conversion is simply /100). The firmware only
+ * ever emits FULL blocks of {@link #NUM_SAMPLES_PER_BLOCK} samples (partial
+ * blocks are discarded on stop - hal_slowSensorSampler.c), so the on-disk
+ * block size is fixed.
+ * <p>
+ * UNCAL = raw centi-degrees C counts; CAL = degrees Celsius. Config comes from
+ * payload header byte 32 (SKIN_TEMP_CONFIG): bit 0 measType (0 = medical,
+ * best accuracy ~25-42.5 C; 1 = extended range), bits 3:1 the MLX90632
+ * refresh-rate code (0..7 = 0.5/1/2/4/8/16/32/64 Hz). The OUTPUT sample rate
+ * the firmware delivers is refresh / sub-measurements (medical = 2,
+ * extended = 3) - mirrors the web SDK's SensorMLX90632.ts. As with the
+ * ambient light, the parser refines the achieved rate per payload from
+ * temp-block tick spacing; the header-derived value seeds the timing.
+ */
+public class SensorMLX90632 extends AbstractSensor {
+
+	private static final long serialVersionUID = 7160245712894913684L;
+
+	public static final int BYTES_PER_SAMPLE = 4;
+	/** Firmware NUM_TEMP_SAMPLES_PER_BLOCK (hal_slowSensorSampler.h). */
+	public static final int NUM_SAMPLES_PER_BLOCK = 16;
+	/** Fixed on-disk sensor-data size of a skin-temp block (no count prefix). */
+	public static final int BLOCK_DATA_BYTES = NUM_SAMPLES_PER_BLOCK * BYTES_PER_SAMPLE;
+
+	/** Refresh-rate code (header byte 32 bits 3:1) -> chip refresh Hz. */
+	public static final double[] REFRESH_HZ_TABLE = {0.5, 1, 2, 4, 8, 16, 32, 64};
+	/** Sub-measurements per output: medical mode = 2, extended mode = 3. */
+	public static final int SUB_MEASUREMENTS_MEDICAL = 2;
+	public static final int SUB_MEASUREMENTS_EXTENDED = 3;
+
+	private int refreshRateCode = 5; // 16 Hz chip refresh (firmware default)
+	private boolean extendedMode = false;
+
+	public class GuiLabelSensors {
+		public static final String SKIN_TEMP = "Skin Temperature";
+	}
+
+	public static class ObjectClusterSensorName {
+		public static String SKIN_TEMP_OBJECT = "SkinTemp_Object";
+		public static String SKIN_TEMP_AMBIENT = "SkinTemp_Ambient";
+	}
+
+	public static class DatabaseChannelHandles {
+		public static final String SKIN_TEMP_OBJECT = "MLX90632_OBJECT";
+		public static final String SKIN_TEMP_AMBIENT = "MLX90632_AMBIENT";
+	}
+
+	//--------- Sensor info start --------------
+	public static final SensorDetailsRef SENSOR_MLX90632 = new SensorDetailsRef(
+			Configuration.Verisense.SensorBitmap.MLX90632,
+			Configuration.Verisense.SensorBitmap.MLX90632,
+			GuiLabelSensors.SKIN_TEMP,
+			CompatibilityInfoForMaps.listOfCompatibleVersionInfoLSM6DSV,
+			Arrays.asList(Configuration.Verisense.SENSOR_ID.MLX90632),
+			Arrays.asList(),
+			Arrays.asList(ObjectClusterSensorName.SKIN_TEMP_OBJECT,
+					ObjectClusterSensorName.SKIN_TEMP_AMBIENT),
+			false);
+
+	public static final Map<Integer, SensorDetailsRef> SENSOR_MAP_REF;
+	static {
+		Map<Integer, SensorDetailsRef> aMap = new LinkedHashMap<Integer, SensorDetailsRef>();
+		aMap.put(Configuration.Verisense.SENSOR_ID.MLX90632, SensorMLX90632.SENSOR_MLX90632);
+		SENSOR_MAP_REF = Collections.unmodifiableMap(aMap);
+	}
+	//--------- Sensor info end --------------
+
+	//--------- Channel info start --------------
+	public static final ChannelDetails CHANNEL_SKIN_TEMP_OBJECT = new ChannelDetails(
+			ObjectClusterSensorName.SKIN_TEMP_OBJECT, ObjectClusterSensorName.SKIN_TEMP_OBJECT, DatabaseChannelHandles.SKIN_TEMP_OBJECT,
+			CHANNEL_DATA_TYPE.INT16, 2, CHANNEL_DATA_ENDIAN.LSB, CHANNEL_UNITS.DEGREES_CELSIUS,
+			Arrays.asList(CHANNEL_TYPE.UNCAL, CHANNEL_TYPE.CAL));
+	public static final ChannelDetails CHANNEL_SKIN_TEMP_AMBIENT = new ChannelDetails(
+			ObjectClusterSensorName.SKIN_TEMP_AMBIENT, ObjectClusterSensorName.SKIN_TEMP_AMBIENT, DatabaseChannelHandles.SKIN_TEMP_AMBIENT,
+			CHANNEL_DATA_TYPE.INT16, 2, CHANNEL_DATA_ENDIAN.LSB, CHANNEL_UNITS.DEGREES_CELSIUS,
+			Arrays.asList(CHANNEL_TYPE.UNCAL, CHANNEL_TYPE.CAL));
+
+	public static final Map<String, ChannelDetails> CHANNEL_MAP_REF;
+	static {
+		Map<String, ChannelDetails> aMap = new LinkedHashMap<String, ChannelDetails>();
+		aMap.put(ObjectClusterSensorName.SKIN_TEMP_OBJECT, CHANNEL_SKIN_TEMP_OBJECT);
+		aMap.put(ObjectClusterSensorName.SKIN_TEMP_AMBIENT, CHANNEL_SKIN_TEMP_AMBIENT);
+		CHANNEL_MAP_REF = Collections.unmodifiableMap(aMap);
+	}
+	//--------- Channel info end --------------
+
+	public SensorMLX90632(ShimmerDevice shimmerDevice) {
+		super(SENSORS.MLX90632, shimmerDevice);
+		initialise();
+	}
+
+	@Override
+	public void generateSensorMap() {
+		super.createLocalSensorMapWithCustomParser(SENSOR_MAP_REF, CHANNEL_MAP_REF);
+	}
+
+	@Override
+	public void generateConfigOptionsMap() {
+		mConfigOptionsMap.clear();
+	}
+
+	@Override
+	public void generateSensorGroupMapping() {
+		// no GUI grouping needed yet (SD-parse only)
+	}
+
+	@Override
+	public ObjectCluster processDataCustom(SensorDetails sensorDetails, byte[] rawData, COMMUNICATION_TYPE commType, ObjectCluster objectCluster, boolean isTimeSyncEnabled, double pcTimestampMs) {
+		objectCluster = sensorDetails.processDataCommon(rawData, commType, objectCluster, isTimeSyncEnabled, pcTimestampMs);
+
+		// Stored values are centi-degrees Celsius (calibration already applied on-chip).
+		double objectCentiC = objectCluster.getFormatClusterValue(CHANNEL_SKIN_TEMP_OBJECT, CHANNEL_TYPE.UNCAL);
+		double ambientCentiC = objectCluster.getFormatClusterValue(CHANNEL_SKIN_TEMP_AMBIENT, CHANNEL_TYPE.UNCAL);
+		int indexBase = objectCluster.getIndexKeeper() - 2;
+		objectCluster.addCalData(CHANNEL_SKIN_TEMP_OBJECT, objectCentiC / 100.0, indexBase);
+		objectCluster.addCalData(CHANNEL_SKIN_TEMP_AMBIENT, ambientCentiC / 100.0, indexBase + 1);
+
+		return objectCluster;
+	}
+
+	@Override
+	public void configBytesParse(ShimmerDevice shimmerDevice, byte[] configBytes, COMMUNICATION_TYPE commType) {
+		if(commType == COMMUNICATION_TYPE.SD && isSensorEnabled(Configuration.Verisense.SENSOR_ID.MLX90632)) {
+			int skinTempConfig = configBytes[PAYLOAD_CONFIG_BYTE_INDEX.SKIN_TEMP_CONFIG] & 0xFF;
+			extendedMode = (skinTempConfig & 0x01) != 0;
+			refreshRateCode = (skinTempConfig >> 1) & 0x07;
+		}
+	}
+
+	@Override
+	public void configBytesGenerate(ShimmerDevice shimmerDevice, byte[] configBytes, COMMUNICATION_TYPE commType) {
+		// SD-parse only for now.
+	}
+
+	public double getRefreshHz() {
+		return REFRESH_HZ_TABLE[refreshRateCode & 0x07];
+	}
+
+	public boolean isExtendedMode() {
+		return extendedMode;
+	}
+
+	public String getMeasTypeString() {
+		return extendedMode ? "Extended" : "Medical";
+	}
+
+	/**
+	 * Header-derived output sample rate (Hz): the chip refresh rate divided by
+	 * the sub-measurements per output (medical = 2, extended = 3). Seeds
+	 * data-block timing; the parser refines the achieved rate per payload from
+	 * temp-block tick spacing.
+	 */
+	public double getRateFreq() {
+		return getRefreshHz() / (extendedMode ? SUB_MEASUREMENTS_EXTENDED : SUB_MEASUREMENTS_MEDICAL);
+	}
+
+	@Override
+	public Object getConfigValueUsingConfigLabel(Integer sensorId, String configLabel) {
+		if(GuiLabelConfigCommon.RATE.equals(configLabel)) {
+			return getRateFreq();
+		}
+		return super.getConfigValueUsingConfigLabelCommon(sensorId, configLabel);
+	}
+
+	@Override
+	public Object setConfigValueUsingConfigLabel(Integer sensorId, String configLabel, Object valueToSet) {
+		return super.setConfigValueUsingConfigLabelCommon(sensorId, configLabel, valueToSet);
+	}
+
+	@Override
+	public void checkShimmerConfigBeforeConfiguring() {
+		// no-op
+	}
+
+	@Override
+	public void setSensorSamplingRate(double samplingRateHz) {
+		// rate is refresh-code driven; nothing to set here
+	}
+
+	@Override
+	public LinkedHashMap<String, Object> generateConfigMap() {
+		return null;
+	}
+
+	@Override
+	public void parseConfigMap(LinkedHashMap<String, Object> mapOfConfigPerShimmer) {
+		// no-op
+	}
+
+	@Override
+	public boolean checkConfigOptionValues(String stringKey) {
+		return false;
+	}
+
+	@Override
+	public boolean setDefaultConfigForSensor(int sensorId, boolean isSensorEnabled) {
+		return false;
+	}
+
+	@Override
+	public boolean processResponse(int responseCommand, Object parsedResponse, COMMUNICATION_TYPE commType) {
+		return false;
+	}
+
+	@Override
+	public Object getSettings(String componentName, COMMUNICATION_TYPE commType) {
+		return null;
+	}
+
+	@Override
+	public com.shimmerresearch.sensors.ActionSetting setSettings(String componentName, Object valueToSet, COMMUNICATION_TYPE commType) {
+		return null;
+	}
+}

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/sensors/SensorVD6283.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/sensors/SensorVD6283.java
@@ -68,7 +68,12 @@ public class SensorVD6283 extends AbstractSensor {
 	public static final int[] EXPOSURE_US_TABLE = {100000, 1600, 6400, 12800, 25600, 51200, 102400, 204800};
 	/** Op-config index -> 8.8 fixed-point gain (firmware vd6283_gainIndexToValue). */
 	public static final int[] GAIN_8P8_TABLE = {0x0100, 0x01AB, 0x0280, 0x0500, 0x0A00, 0x1900, 0x3200, 0x42AB};
-	/** Reference exposure the normalisation is relative to (firmware VD6283TX_DEFAULT_EXPO). */
+	/** Reference exposure the normalisation is relative to (firmware
+	 * VD6283TX_DEFAULT_EXPO = 100800). NOTE this deliberately differs from
+	 * EXPOSURE_US_TABLE[0] (100000): the firmware normalises against 100800
+	 * regardless of the configured exposure, so a 1.008 scale factor at the
+	 * default exposure is firmware-faithful (verified against App_vd6283tx.c;
+	 * the web SDK uses the same pair). */
 	public static final double DEFAULT_EXPO_US = 100800;
 	/** ALS-counts -> XYZ matrix (firmware App_vd6283tx.c). Rows are X, Y, Z. */
 	private static final double[][] XYZ_MATRIX = {
@@ -118,7 +123,8 @@ public class SensorVD6283 extends AbstractSensor {
 			Configuration.Verisense.SensorBitmap.VD6283,
 			GuiLabelSensors.LIGHT,
 			CompatibilityInfoForMaps.listOfCompatibleVersionInfoLSM6DSV,
-			Arrays.asList(Configuration.Verisense.SENSOR_ID.VD6283),
+			// listOfSensorIdsConflicting - none (gen-1 convention, e.g. SENSOR_GSR_VERISENSE)
+			new java.util.ArrayList<Integer>(),
 			Arrays.asList(),
 			Arrays.asList(ObjectClusterSensorName.LIGHT_RED,
 					ObjectClusterSensorName.LIGHT_VISIBLE,
@@ -173,6 +179,11 @@ public class SensorVD6283 extends AbstractSensor {
 		aMap.put(ObjectClusterSensorName.LIGHT_LUX, CHANNEL_LIGHT_LUX);
 		aMap.put(ObjectClusterSensorName.LIGHT_CCT, CHANNEL_LIGHT_CCT);
 		CHANNEL_MAP_REF = Collections.unmodifiableMap(aMap);
+
+		// Computed (API-side) channels, not part of the on-disk packet - repo
+		// convention per SensorGSR.
+		CHANNEL_LIGHT_LUX.mChannelSource = ChannelDetails.CHANNEL_SOURCE.API;
+		CHANNEL_LIGHT_CCT.mChannelSource = ChannelDetails.CHANNEL_SOURCE.API;
 	}
 	//--------- Channel info end --------------
 
@@ -253,8 +264,17 @@ public class SensorVD6283 extends AbstractSensor {
 		if (norm != 0) {
 			double x = X / norm;
 			double y = Y / norm;
-			double n = (x - 0.3320) / (0.1858 - y);
-			cct = 449*n*n*n + 3525*n*n + 6823.3*n + 5520.33;
+			double denominator = 0.1858 - y;
+			if (denominator != 0) {
+				double n = (x - 0.3320) / denominator;
+				cct = 449*n*n*n + 3525*n*n + 6823.3*n + 5520.33;
+			}
+			// McCamy's polynomial is only meaningful for positive colour
+			// temperatures; clamp the out-of-gamut cases (like lux above) so
+			// no negative/undefined CCT reaches the CSV.
+			if (!(cct > 0) || Double.isInfinite(cct)) {
+				cct = 0;
+			}
 		}
 		return new double[] {lux, cct};
 	}

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/sensors/SensorVD6283.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/sensors/SensorVD6283.java
@@ -1,0 +1,356 @@
+package com.shimmerresearch.verisense.sensors;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.shimmerresearch.driver.Configuration;
+import com.shimmerresearch.driver.Configuration.CHANNEL_UNITS;
+import com.shimmerresearch.driver.Configuration.COMMUNICATION_TYPE;
+import com.shimmerresearch.driver.Configuration.Verisense.CompatibilityInfoForMaps;
+import com.shimmerresearch.driver.ObjectCluster;
+import com.shimmerresearch.driver.ShimmerDevice;
+import com.shimmerresearch.driverUtilities.ChannelDetails;
+import com.shimmerresearch.driverUtilities.ChannelDetails.CHANNEL_DATA_ENDIAN;
+import com.shimmerresearch.driverUtilities.ChannelDetails.CHANNEL_DATA_TYPE;
+import com.shimmerresearch.driverUtilities.ChannelDetails.CHANNEL_TYPE;
+import com.shimmerresearch.driverUtilities.SensorDetails;
+import com.shimmerresearch.driverUtilities.SensorDetailsRef;
+import com.shimmerresearch.sensors.AbstractSensor;
+import com.shimmerresearch.verisense.payloaddesign.AsmBinaryFileConstants.PAYLOAD_CONFIG_BYTE_INDEX;
+
+/**
+ * Decoder for the VD6283TX45 ambient light sensor (Verisense data-block sensor
+ * id = 7, second-generation hardware). Data block = N samples x 18 bytes: 6
+ * channels x 24-bit LE raw ALS counts in order RED, VISIBLE, BLUE, GREEN, IR,
+ * CLEAR. The firmware only ever emits FULL blocks of
+ * {@link #NUM_SAMPLES_PER_BLOCK} samples (partial blocks are discarded on stop
+ * - hal_slowSensorSampler.c), so the on-disk block size is fixed.
+ * <p>
+ * UNCAL = raw 24-bit counts. CAL = counts normalised for the configured gain
+ * and exposure (both recorded in payload header bytes 30/31), plus the derived
+ * illuminance (lux) and correlated colour temperature (CCT) computed from the
+ * normalised RED/GREEN/BLUE channels via the VD6283 ALS-to-XYZ matrix and
+ * McCamy's polynomial - ported from firmware App_vd6283tx.c and kept in step
+ * with the web SDK's SensorVD6283.ts.
+ * <p>
+ * NOTE (dark channel): when the op-config dark-channel bit is set (header byte
+ * 30 bit 7) the chip routes the covered-photodiode DARK baseline onto the
+ * second slot INSTEAD of the visible reading. The slot's column is currently
+ * always named {@code Light_Visible}; the "Slot1 = Visible|Dark" entry in the
+ * CSV sensor-config line records which reading it actually carries. RED, GREEN
+ * and BLUE are unaffected, so lux/CCT remain valid in either mode. No
+ * dark-enabled recording exists yet - revisit the naming when one does.
+ * <p>
+ * The sample rate is configured in the op config (LIGHT_SAMPLE_RATE_INDEX) but
+ * is NOT mirrored into the stored payload header, and the achieved rate also
+ * differs from both the configured rate and 1/exposure (the chip adds dead
+ * time per measurement, e.g. ~110 ms/sample for the 100 ms exposure). The
+ * getRateFreq() value here is therefore only the exposure-limited ESTIMATE
+ * used to seed data-block timing; the parser refines it per payload from the
+ * spacing of consecutive light-block timestamps
+ * (PayloadContentsDetailsV8orAbove.refineLightSamplingRateFromBlockTicks).
+ */
+public class SensorVD6283 extends AbstractSensor {
+
+	private static final long serialVersionUID = 5804427848836576803L;
+
+	public static final int NUM_CHANNELS = 6;
+	public static final int BYTES_PER_CHANNEL = 3;
+	public static final int BYTES_PER_SAMPLE = NUM_CHANNELS * BYTES_PER_CHANNEL;
+	/** Firmware NUM_LIGHT_SAMPLES_PER_BLOCK (hal_slowSensorSampler.h). */
+	public static final int NUM_SAMPLES_PER_BLOCK = 10;
+	/** Fixed on-disk sensor-data size of a light block (no count prefix). */
+	public static final int BLOCK_DATA_BYTES = NUM_SAMPLES_PER_BLOCK * BYTES_PER_SAMPLE;
+
+	/** Op-config index -> exposure us (firmware vd6283_exposureIndexToUs). */
+	public static final int[] EXPOSURE_US_TABLE = {100000, 1600, 6400, 12800, 25600, 51200, 102400, 204800};
+	/** Op-config index -> 8.8 fixed-point gain (firmware vd6283_gainIndexToValue). */
+	public static final int[] GAIN_8P8_TABLE = {0x0100, 0x01AB, 0x0280, 0x0500, 0x0A00, 0x1900, 0x3200, 0x42AB};
+	/** Reference exposure the normalisation is relative to (firmware VD6283TX_DEFAULT_EXPO). */
+	public static final double DEFAULT_EXPO_US = 100800;
+	/** ALS-counts -> XYZ matrix (firmware App_vd6283tx.c). Rows are X, Y, Z. */
+	private static final double[][] XYZ_MATRIX = {
+			{0.205570, 0.416700, -0.143816},
+			{-0.028752, 0.506372, -0.120614},
+			{-0.552625, 0.335866, 0.494781}};
+
+	/** Poll ceiling in continuous mode (firmware slow-sensor sampler). */
+	public static final double MAX_SAMPLE_RATE_HZ = 20.0;
+
+	public static final String UNITS_LUX = "lux";
+	public static final String UNITS_KELVIN = "Kelvin";
+
+	private int gainIndex = 0;
+	private int exposureIndex = 0;
+	private boolean darkChannelEnabled = false;
+
+	public class GuiLabelSensors {
+		public static final String LIGHT = "Light";
+	}
+
+	public static class ObjectClusterSensorName {
+		public static String LIGHT_RED = "Light_Red";
+		public static String LIGHT_VISIBLE = "Light_Visible";
+		public static String LIGHT_BLUE = "Light_Blue";
+		public static String LIGHT_GREEN = "Light_Green";
+		public static String LIGHT_IR = "Light_IR";
+		public static String LIGHT_CLEAR = "Light_Clear";
+		public static String LIGHT_LUX = "Light_Lux";
+		public static String LIGHT_CCT = "Light_CCT";
+	}
+
+	public static class DatabaseChannelHandles {
+		public static final String LIGHT_RED = "VD6283_RED";
+		public static final String LIGHT_VISIBLE = "VD6283_VISIBLE";
+		public static final String LIGHT_BLUE = "VD6283_BLUE";
+		public static final String LIGHT_GREEN = "VD6283_GREEN";
+		public static final String LIGHT_IR = "VD6283_IR";
+		public static final String LIGHT_CLEAR = "VD6283_CLEAR";
+		public static final String LIGHT_LUX = "VD6283_LUX";
+		public static final String LIGHT_CCT = "VD6283_CCT";
+	}
+
+	//--------- Sensor info start --------------
+	public static final SensorDetailsRef SENSOR_VD6283 = new SensorDetailsRef(
+			Configuration.Verisense.SensorBitmap.VD6283,
+			Configuration.Verisense.SensorBitmap.VD6283,
+			GuiLabelSensors.LIGHT,
+			CompatibilityInfoForMaps.listOfCompatibleVersionInfoLSM6DSV,
+			Arrays.asList(Configuration.Verisense.SENSOR_ID.VD6283),
+			Arrays.asList(),
+			Arrays.asList(ObjectClusterSensorName.LIGHT_RED,
+					ObjectClusterSensorName.LIGHT_VISIBLE,
+					ObjectClusterSensorName.LIGHT_BLUE,
+					ObjectClusterSensorName.LIGHT_GREEN,
+					ObjectClusterSensorName.LIGHT_IR,
+					ObjectClusterSensorName.LIGHT_CLEAR,
+					ObjectClusterSensorName.LIGHT_LUX,
+					ObjectClusterSensorName.LIGHT_CCT),
+			false);
+
+	public static final Map<Integer, SensorDetailsRef> SENSOR_MAP_REF;
+	static {
+		Map<Integer, SensorDetailsRef> aMap = new LinkedHashMap<Integer, SensorDetailsRef>();
+		aMap.put(Configuration.Verisense.SENSOR_ID.VD6283, SensorVD6283.SENSOR_VD6283);
+		SENSOR_MAP_REF = Collections.unmodifiableMap(aMap);
+	}
+	//--------- Sensor info end --------------
+
+	//--------- Channel info start --------------
+	private static ChannelDetails createRawChannel(String objectClusterName, String databaseName) {
+		return new ChannelDetails(objectClusterName, objectClusterName, databaseName,
+				CHANNEL_DATA_TYPE.UINT24, BYTES_PER_CHANNEL, CHANNEL_DATA_ENDIAN.LSB, CHANNEL_UNITS.NO_UNITS,
+				Arrays.asList(CHANNEL_TYPE.UNCAL, CHANNEL_TYPE.CAL));
+	}
+
+	public static final ChannelDetails CHANNEL_LIGHT_RED = createRawChannel(ObjectClusterSensorName.LIGHT_RED, DatabaseChannelHandles.LIGHT_RED);
+	public static final ChannelDetails CHANNEL_LIGHT_VISIBLE = createRawChannel(ObjectClusterSensorName.LIGHT_VISIBLE, DatabaseChannelHandles.LIGHT_VISIBLE);
+	public static final ChannelDetails CHANNEL_LIGHT_BLUE = createRawChannel(ObjectClusterSensorName.LIGHT_BLUE, DatabaseChannelHandles.LIGHT_BLUE);
+	public static final ChannelDetails CHANNEL_LIGHT_GREEN = createRawChannel(ObjectClusterSensorName.LIGHT_GREEN, DatabaseChannelHandles.LIGHT_GREEN);
+	public static final ChannelDetails CHANNEL_LIGHT_IR = createRawChannel(ObjectClusterSensorName.LIGHT_IR, DatabaseChannelHandles.LIGHT_IR);
+	public static final ChannelDetails CHANNEL_LIGHT_CLEAR = createRawChannel(ObjectClusterSensorName.LIGHT_CLEAR, DatabaseChannelHandles.LIGHT_CLEAR);
+
+	/** Computed channel - no bytes in the data packet (CAL only). */
+	public static final ChannelDetails CHANNEL_LIGHT_LUX = new ChannelDetails(
+			ObjectClusterSensorName.LIGHT_LUX, ObjectClusterSensorName.LIGHT_LUX, DatabaseChannelHandles.LIGHT_LUX,
+			UNITS_LUX, Arrays.asList(CHANNEL_TYPE.CAL));
+	/** Computed channel - no bytes in the data packet (CAL only). */
+	public static final ChannelDetails CHANNEL_LIGHT_CCT = new ChannelDetails(
+			ObjectClusterSensorName.LIGHT_CCT, ObjectClusterSensorName.LIGHT_CCT, DatabaseChannelHandles.LIGHT_CCT,
+			UNITS_KELVIN, Arrays.asList(CHANNEL_TYPE.CAL));
+
+	public static final Map<String, ChannelDetails> CHANNEL_MAP_REF;
+	static {
+		Map<String, ChannelDetails> aMap = new LinkedHashMap<String, ChannelDetails>();
+		aMap.put(ObjectClusterSensorName.LIGHT_RED, CHANNEL_LIGHT_RED);
+		aMap.put(ObjectClusterSensorName.LIGHT_VISIBLE, CHANNEL_LIGHT_VISIBLE);
+		aMap.put(ObjectClusterSensorName.LIGHT_BLUE, CHANNEL_LIGHT_BLUE);
+		aMap.put(ObjectClusterSensorName.LIGHT_GREEN, CHANNEL_LIGHT_GREEN);
+		aMap.put(ObjectClusterSensorName.LIGHT_IR, CHANNEL_LIGHT_IR);
+		aMap.put(ObjectClusterSensorName.LIGHT_CLEAR, CHANNEL_LIGHT_CLEAR);
+		aMap.put(ObjectClusterSensorName.LIGHT_LUX, CHANNEL_LIGHT_LUX);
+		aMap.put(ObjectClusterSensorName.LIGHT_CCT, CHANNEL_LIGHT_CCT);
+		CHANNEL_MAP_REF = Collections.unmodifiableMap(aMap);
+	}
+	//--------- Channel info end --------------
+
+	public SensorVD6283(ShimmerDevice shimmerDevice) {
+		super(SENSORS.VD6283, shimmerDevice);
+		initialise();
+	}
+
+	@Override
+	public void generateSensorMap() {
+		super.createLocalSensorMapWithCustomParser(SENSOR_MAP_REF, CHANNEL_MAP_REF);
+	}
+
+	@Override
+	public void generateConfigOptionsMap() {
+		mConfigOptionsMap.clear();
+	}
+
+	@Override
+	public void generateSensorGroupMapping() {
+		// no GUI grouping needed yet (SD-parse only)
+	}
+
+	@Override
+	public ObjectCluster processDataCustom(SensorDetails sensorDetails, byte[] rawData, COMMUNICATION_TYPE commType, ObjectCluster objectCluster, boolean isTimeSyncEnabled, double pcTimestampMs) {
+		// UNCAL for the six 24-bit count channels; the two computed channels have no
+		// bytes in the packet so processDataCommon adds a harmless 0 for them.
+		objectCluster = sensorDetails.processDataCommon(rawData, commType, objectCluster, isTimeSyncEnabled, pcTimestampMs);
+
+		double red = objectCluster.getFormatClusterValue(CHANNEL_LIGHT_RED, CHANNEL_TYPE.UNCAL);
+		double visibleOrDark = objectCluster.getFormatClusterValue(CHANNEL_LIGHT_VISIBLE, CHANNEL_TYPE.UNCAL);
+		double blue = objectCluster.getFormatClusterValue(CHANNEL_LIGHT_BLUE, CHANNEL_TYPE.UNCAL);
+		double green = objectCluster.getFormatClusterValue(CHANNEL_LIGHT_GREEN, CHANNEL_TYPE.UNCAL);
+		double ir = objectCluster.getFormatClusterValue(CHANNEL_LIGHT_IR, CHANNEL_TYPE.UNCAL);
+		double clear = objectCluster.getFormatClusterValue(CHANNEL_LIGHT_CLEAR, CHANNEL_TYPE.UNCAL);
+
+		// CAL = gain/exposure-normalised counts (comparable across configurations).
+		int indexBase = objectCluster.getIndexKeeper() - 8;
+		objectCluster.addCalData(CHANNEL_LIGHT_RED, normalizeForXyz(red), indexBase);
+		objectCluster.addCalData(CHANNEL_LIGHT_VISIBLE, normalizeForXyz(visibleOrDark), indexBase + 1);
+		objectCluster.addCalData(CHANNEL_LIGHT_BLUE, normalizeForXyz(blue), indexBase + 2);
+		objectCluster.addCalData(CHANNEL_LIGHT_GREEN, normalizeForXyz(green), indexBase + 3);
+		objectCluster.addCalData(CHANNEL_LIGHT_IR, normalizeForXyz(ir), indexBase + 4);
+		objectCluster.addCalData(CHANNEL_LIGHT_CLEAR, normalizeForXyz(clear), indexBase + 5);
+
+		// lux/CCT derive from RED/GREEN/BLUE, so the dark-channel selection (which
+		// only affects the second slot) leaves them valid in either mode.
+		double[] luxCct = computeLuxCct(red, green, blue);
+		objectCluster.addCalData(CHANNEL_LIGHT_LUX, luxCct[0], indexBase + 6);
+		objectCluster.addCalData(CHANNEL_LIGHT_CCT, luxCct[1], indexBase + 7);
+
+		return objectCluster;
+	}
+
+	/** Normalise a raw channel count for the XYZ transform (gain + exposure divided
+	 * out). Float division - slightly more precise than the firmware's integer
+	 * division of the 16.8/8.8 fixed-point values; differences are small. */
+	public double normalizeForXyz(double count) {
+		double gain8p8 = GAIN_8P8_TABLE[gainIndex & 0x07];
+		double expoScale = DEFAULT_EXPO_US / getExposureUs();
+		return (expoScale * (count / 256.0)) / (gain8p8 / 256.0);
+	}
+
+	/** Illuminance (lux, XYZ Y clamped to >= 0) and CCT (Kelvin, McCamy; 0 if
+	 * undefined) from raw RED/GREEN/BLUE counts. */
+	public double[] computeLuxCct(double red, double green, double blue) {
+		double r = normalizeForXyz(red);
+		double g = normalizeForXyz(green);
+		double b = normalizeForXyz(blue);
+
+		double X = XYZ_MATRIX[0][0]*r + XYZ_MATRIX[0][1]*g + XYZ_MATRIX[0][2]*b;
+		double Y = XYZ_MATRIX[1][0]*r + XYZ_MATRIX[1][1]*g + XYZ_MATRIX[1][2]*b;
+		double Z = XYZ_MATRIX[2][0]*r + XYZ_MATRIX[2][1]*g + XYZ_MATRIX[2][2]*b;
+
+		double lux = Y < 0 ? 0 : Y;
+		double norm = X + Y + Z;
+		double cct = 0;
+		if (norm != 0) {
+			double x = X / norm;
+			double y = Y / norm;
+			double n = (x - 0.3320) / (0.1858 - y);
+			cct = 449*n*n*n + 3525*n*n + 6823.3*n + 5520.33;
+		}
+		return new double[] {lux, cct};
+	}
+
+	@Override
+	public void configBytesParse(ShimmerDevice shimmerDevice, byte[] configBytes, COMMUNICATION_TYPE commType) {
+		if(commType == COMMUNICATION_TYPE.SD && isSensorEnabled(Configuration.Verisense.SENSOR_ID.VD6283)) {
+			int gainAndDark = configBytes[PAYLOAD_CONFIG_BYTE_INDEX.LIGHT_GAIN_AND_DARK] & 0xFF;
+			gainIndex = gainAndDark & 0x07;
+			darkChannelEnabled = (gainAndDark & 0x80) != 0;
+			exposureIndex = configBytes[PAYLOAD_CONFIG_BYTE_INDEX.LIGHT_EXPOSURE] & 0xFF;
+		}
+	}
+
+	@Override
+	public void configBytesGenerate(ShimmerDevice shimmerDevice, byte[] configBytes, COMMUNICATION_TYPE commType) {
+		// SD-parse only for now.
+	}
+
+	public int getExposureUs() {
+		return EXPOSURE_US_TABLE[(exposureIndex >= 0 && exposureIndex < EXPOSURE_US_TABLE.length) ? exposureIndex : 0];
+	}
+
+	public double getGain() {
+		return GAIN_8P8_TABLE[gainIndex & 0x07] / 256.0;
+	}
+
+	public boolean isDarkChannelEnabled() {
+		return darkChannelEnabled;
+	}
+
+	/**
+	 * Exposure-limited sample-rate ESTIMATE (Hz). The configured rate is not in
+	 * the stored payload header and the chip adds per-measurement dead time, so
+	 * this only seeds data-block timing - the parser refines the rate per payload
+	 * from consecutive light-block timestamps.
+	 */
+	public double getRateFreq() {
+		return Math.min(MAX_SAMPLE_RATE_HZ, 1e6 / getExposureUs());
+	}
+
+	@Override
+	public Object getConfigValueUsingConfigLabel(Integer sensorId, String configLabel) {
+		if(GuiLabelConfigCommon.RATE.equals(configLabel)) {
+			return getRateFreq();
+		}
+		return super.getConfigValueUsingConfigLabelCommon(sensorId, configLabel);
+	}
+
+	@Override
+	public Object setConfigValueUsingConfigLabel(Integer sensorId, String configLabel, Object valueToSet) {
+		return super.setConfigValueUsingConfigLabelCommon(sensorId, configLabel, valueToSet);
+	}
+
+	@Override
+	public void checkShimmerConfigBeforeConfiguring() {
+		// no-op
+	}
+
+	@Override
+	public void setSensorSamplingRate(double samplingRateHz) {
+		// rate is exposure/op-config driven; nothing to set here
+	}
+
+	@Override
+	public LinkedHashMap<String, Object> generateConfigMap() {
+		return null;
+	}
+
+	@Override
+	public void parseConfigMap(LinkedHashMap<String, Object> mapOfConfigPerShimmer) {
+		// no-op
+	}
+
+	@Override
+	public boolean checkConfigOptionValues(String stringKey) {
+		return false;
+	}
+
+	@Override
+	public boolean setDefaultConfigForSensor(int sensorId, boolean isSensorEnabled) {
+		return false;
+	}
+
+	@Override
+	public boolean processResponse(int responseCommand, Object parsedResponse, COMMUNICATION_TYPE commType) {
+		return false;
+	}
+
+	@Override
+	public Object getSettings(String componentName, COMMUNICATION_TYPE commType) {
+		return null;
+	}
+
+	@Override
+	public com.shimmerresearch.sensors.ActionSetting setSettings(String componentName, Object valueToSet, COMMUNICATION_TYPE commType) {
+		return null;
+	}
+}

--- a/ShimmerDriver/src/test/java/com/shimmerresearch/verisense/API_00008_VerisenseLsm6dsvTaggedFifoParsing.java
+++ b/ShimmerDriver/src/test/java/com/shimmerresearch/verisense/API_00008_VerisenseLsm6dsvTaggedFifoParsing.java
@@ -1,0 +1,197 @@
+package com.shimmerresearch.verisense;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+
+import org.junit.Test;
+
+import com.shimmerresearch.driver.Configuration.COMMUNICATION_TYPE;
+import com.shimmerresearch.driver.Configuration.Verisense;
+import com.shimmerresearch.driver.ObjectCluster;
+import com.shimmerresearch.driverUtilities.ChannelDetails.CHANNEL_TYPE;
+import com.shimmerresearch.driverUtilities.ExpansionBoardDetails;
+import com.shimmerresearch.driverUtilities.ShimmerVerDetails.HW_ID;
+import com.shimmerresearch.verisense.VerisenseDevice.FW_CHANGES;
+import com.shimmerresearch.verisense.payloaddesign.DataBlockDetails;
+import com.shimmerresearch.verisense.sensors.SensorLSM6DSV;
+
+/**
+ * Unit tests for the second-generation LSM6DSV variable-length tagged-FIFO data
+ * block parsing in {@link VerisenseDevice} using small synthetic FIFO blocks
+ * (no binary test files needed). The block layout under test is
+ * {@code [SENSOR_ID=6][3-byte ticks][2-byte NUM_ENTRIES][N x 7-byte entries]}
+ * where each entry is {@code [TAG_CNT][X lsb][X msb][Y lsb][Y msb][Z lsb][Z msb]}
+ * and the 5-bit tag (TAG_CNT bits 7:3) identifies the stream.
+ * <p>
+ * End-to-end coverage against real SR68-9 recordings lives in
+ * ASM_PC_00005_VerisenseFileParserPC (Test_028-047, ASM_PC repository).
+ *
+ * @author Mark Nolan
+ */
+public class API_00008_VerisenseLsm6dsvTaggedFifoParsing {
+
+	private static final int TAG_GYRO = 0x01;
+	private static final int TAG_ACCEL = 0x02;
+	private static final int TAG_TIMESTAMP = 0x04;
+	private static final int TAG_MAG = 0x0E;
+
+	/**
+	 * Set up the device exactly as the binary-file parse flow does: by parsing a
+	 * synthetic second-generation (payload design v13, 32-byte) payload config
+	 * header. This also exercises the gen-2 enabled-sensor mapping (PAYLOAD_CONFIG0
+	 * bits 6/5 -> LSM6DSV accel/gyro, GEN_CFG_3 bit 2 -> mag).
+	 */
+	private VerisenseDevice setupGen2Device(boolean accelEn, boolean gyroEn, boolean magEn) {
+		VerisenseDevice device = new VerisenseDevice(COMMUNICATION_TYPE.SD);
+
+		byte[] configBytes = new byte[32];
+		configBytes[0] = (byte) (0x10 | (accelEn ? 0x40 : 0) | (gyroEn ? 0x20 : 0)); // extended-config flag + enables
+		configBytes[2] = 2;  // FW major
+		configBytes[3] = 0;  // FW minor
+		configBytes[4] = 9;  // FW internal LSB (v2.00.009)
+		configBytes[5] = 0;  // FW internal MSB
+		configBytes[6] = (byte) 0xFF; // reset reason
+		configBytes[11] = HW_ID.VERISENSE_PULSE_PLUS; // HW major = 68 (SR68)
+		configBytes[12] = 9;  // HW minor (SR68-9 = second-generation)
+		configBytes[14] = (byte) (accelEn ? 0x15 : 0x10); // LSM6DSV_CFG_0: accel ODR 60 Hz (or off), FS +-4g
+		configBytes[15] = (byte) (gyroEn ? 0x25 : 0x20);  // LSM6DSV_CFG_1: gyro ODR 60 Hz (or off), FS +-500dps
+		configBytes[16] = 0x01; // LSM6DSV_CFG_2: mag rate 30 Hz
+		configBytes[25] = (byte) (0x02 | (magEn ? 0x04 : 0)); // GEN_CFG_3: LED mode + MAG_EN bit 2
+		device.configBytesParse(configBytes, COMMUNICATION_TYPE.SD);
+
+		return device;
+	}
+
+	private static byte[] entry(int tag, int x, int y, int z) {
+		return new byte[] {
+				(byte) ((tag & 0x1F) << 3),
+				(byte) (x & 0xFF), (byte) ((x >> 8) & 0xFF),
+				(byte) (y & 0xFF), (byte) ((y >> 8) & 0xFF),
+				(byte) (z & 0xFF), (byte) ((z >> 8) & 0xFF) };
+	}
+
+	/** [id=6][ticks(3)][numEntries(2)][entries] */
+	private static byte[] buildDataBlock(byte[]... entries) {
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		baos.write(6);
+		baos.write(0x10); baos.write(0x20); baos.write(0x30); // arbitrary ticks
+		baos.write(entries.length & 0xFF);
+		baos.write((entries.length >> 8) & 0xFF);
+		for (byte[] e : entries) {
+			baos.write(e, 0, e.length);
+		}
+		return baos.toByteArray();
+	}
+
+	private DataBlockDetails parseBlock(VerisenseDevice device, byte[] block) throws Exception {
+		DataBlockDetails dataBlockDetails = device.parseDataBlockMetaData(block, 0, 0, 0, 0);
+		// In the production flow parseDataBlockData is called with the index pointing
+		// just past [SENSOR_ID][ticks] (see PayloadContentsDetailsV8orAbove)
+		device.parseDataBlockData(dataBlockDetails, block, 4, COMMUNICATION_TYPE.SD);
+		return dataBlockDetails;
+	}
+
+	private static double uncal(ObjectCluster ojc, String channelName) {
+		return ojc.getFormatClusterValue(channelName, CHANNEL_TYPE.UNCAL.toString());
+	}
+
+	/** Accel + gyro interleaved 1:1 with a mag sample and a timestamp entry mixed in. */
+	@Test
+	public void test001_accelGyroMagInterleaved() throws Exception {
+		VerisenseDevice device = setupGen2Device(true, true, true);
+		byte[] block = buildDataBlock(
+				entry(TAG_TIMESTAMP, 0, 0, 0),     // must be skipped
+				entry(TAG_GYRO, 10, -20, 30),
+				entry(TAG_ACCEL, 100, -200, 300),
+				entry(TAG_MAG, -150, 5, 150),
+				entry(TAG_GYRO, 11, -21, 31),
+				entry(TAG_ACCEL, 101, -201, 301));
+		DataBlockDetails dataBlockDetails = parseBlock(device, block);
+
+		// sample count follows the aligned accel stream; OJC array = aligned + mag
+		assertEquals(2, dataBlockDetails.getSampleCount());
+		assertEquals(3, dataBlockDetails.getOjcArray().length);
+
+		// aligned OJCs carry accel+gyro but NO mag channels (no cross-pollution)
+		ObjectCluster aligned0 = dataBlockDetails.getOjcArray()[0];
+		assertEquals(100, uncal(aligned0, SensorLSM6DSV.ObjectClusterSensorName.LSM6DSV_ACC_X), 0.001);
+		assertEquals(-200, uncal(aligned0, SensorLSM6DSV.ObjectClusterSensorName.LSM6DSV_ACC_Y), 0.001);
+		assertEquals(300, uncal(aligned0, SensorLSM6DSV.ObjectClusterSensorName.LSM6DSV_ACC_Z), 0.001);
+		assertEquals(10, uncal(aligned0, SensorLSM6DSV.ObjectClusterSensorName.LSM6DSV_GYRO_X), 0.001);
+		assertTrue(Double.isNaN(uncal(aligned0, SensorLSM6DSV.ObjectClusterSensorName.LIS2MDL_MAG_X)));
+
+		ObjectCluster aligned1 = dataBlockDetails.getOjcArray()[1];
+		assertEquals(101, uncal(aligned1, SensorLSM6DSV.ObjectClusterSensorName.LSM6DSV_ACC_X), 0.001);
+		assertEquals(11, uncal(aligned1, SensorLSM6DSV.ObjectClusterSensorName.LSM6DSV_GYRO_X), 0.001);
+
+		// the mag OJC carries mag but NO accel/gyro channels
+		ObjectCluster magOjc = dataBlockDetails.getOjcArray()[2];
+		assertEquals(-150, uncal(magOjc, SensorLSM6DSV.ObjectClusterSensorName.LIS2MDL_MAG_X), 0.001);
+		assertEquals(5, uncal(magOjc, SensorLSM6DSV.ObjectClusterSensorName.LIS2MDL_MAG_Y), 0.001);
+		assertEquals(150, uncal(magOjc, SensorLSM6DSV.ObjectClusterSensorName.LIS2MDL_MAG_Z), 0.001);
+		assertTrue(Double.isNaN(uncal(magOjc, SensorLSM6DSV.ObjectClusterSensorName.LSM6DSV_ACC_X)));
+		assertTrue(Double.isNaN(uncal(magOjc, SensorLSM6DSV.ObjectClusterSensorName.LSM6DSV_GYRO_X)));
+	}
+
+	/** Gyro-only: gyro acts as the aligned reference stream. */
+	@Test
+	public void test002_gyroOnly() throws Exception {
+		VerisenseDevice device = setupGen2Device(false, true, false);
+		byte[] block = buildDataBlock(
+				entry(TAG_GYRO, 1, 2, 3),
+				entry(TAG_TIMESTAMP, 0, 0, 0),
+				entry(TAG_GYRO, 4, 5, 6),
+				entry(TAG_GYRO, 7, 8, 9));
+		DataBlockDetails dataBlockDetails = parseBlock(device, block);
+
+		assertEquals(3, dataBlockDetails.getSampleCount());
+		assertEquals(3, dataBlockDetails.getOjcArray().length);
+		assertEquals(4, uncal(dataBlockDetails.getOjcArray()[1], SensorLSM6DSV.ObjectClusterSensorName.LSM6DSV_GYRO_X), 0.001);
+	}
+
+	/**
+	 * Mag-only enable configuration. Not currently producible by the firmware (the
+	 * LSM6DSV sensor hub requires accel and/or gyro to be running) but expressible
+	 * in the payload header, so the parser handles it defensively: the mag stream
+	 * acts as the reference for the sample count and all samples are emitted.
+	 */
+	@Test
+	public void test003_magOnly() throws Exception {
+		VerisenseDevice device = setupGen2Device(false, false, true);
+		byte[] block = buildDataBlock(
+				entry(TAG_MAG, -100, 0, 100),
+				entry(TAG_MAG, -101, 1, 101));
+		DataBlockDetails dataBlockDetails = parseBlock(device, block);
+
+		assertEquals(2, dataBlockDetails.getSampleCount());
+		assertEquals(2, dataBlockDetails.getOjcArray().length);
+		assertEquals(-100, uncal(dataBlockDetails.getOjcArray()[0], SensorLSM6DSV.ObjectClusterSensorName.LIS2MDL_MAG_X), 0.001);
+		assertEquals(-101, uncal(dataBlockDetails.getOjcArray()[1], SensorLSM6DSV.ObjectClusterSensorName.LIS2MDL_MAG_X), 0.001);
+	}
+
+	/** The per-stream enable toggling inside the parser must be restored afterwards. */
+	@Test
+	public void test004_enableStateRestoredAfterParse() throws Exception {
+		VerisenseDevice device = setupGen2Device(true, true, true);
+		byte[] block = buildDataBlock(
+				entry(TAG_ACCEL, 1, 2, 3),
+				entry(TAG_GYRO, 4, 5, 6),
+				entry(TAG_MAG, 7, 8, 9));
+		parseBlock(device, block);
+
+		assertTrue(device.isSensorEnabled(Verisense.SENSOR_ID.LSM6DSV_ACCEL));
+		assertTrue(device.isSensorEnabled(Verisense.SENSOR_ID.LSM6DSV_GYRO));
+		assertTrue(device.isSensorEnabled(Verisense.SENSOR_ID.LSM6DSV_MAG));
+
+		// and a disabled stream stays disabled
+		VerisenseDevice deviceAccelOnly = setupGen2Device(true, false, false);
+		parseBlock(deviceAccelOnly, buildDataBlock(entry(TAG_ACCEL, 1, 2, 3)));
+		assertTrue(deviceAccelOnly.isSensorEnabled(Verisense.SENSOR_ID.LSM6DSV_ACCEL));
+		assertFalse(deviceAccelOnly.isSensorEnabled(Verisense.SENSOR_ID.LSM6DSV_GYRO));
+		assertFalse(deviceAccelOnly.isSensorEnabled(Verisense.SENSOR_ID.LSM6DSV_MAG));
+	}
+
+}

--- a/ShimmerDriver/src/test/java/com/shimmerresearch/verisense/API_00008_VerisenseLsm6dsvTaggedFifoParsing.java
+++ b/ShimmerDriver/src/test/java/com/shimmerresearch/verisense/API_00008_VerisenseLsm6dsvTaggedFifoParsing.java
@@ -98,6 +98,10 @@ public class API_00008_VerisenseLsm6dsvTaggedFifoParsing {
 		return ojc.getFormatClusterValue(channelName, CHANNEL_TYPE.UNCAL.toString());
 	}
 
+	private static double cal(ObjectCluster ojc, String channelName) {
+		return ojc.getFormatClusterValue(channelName, CHANNEL_TYPE.CAL.toString());
+	}
+
 	/** Accel + gyro interleaved 1:1 with a mag sample and a timestamp entry mixed in. */
 	@Test
 	public void test001_accelGyroMagInterleaved() throws Exception {
@@ -134,6 +138,16 @@ public class API_00008_VerisenseLsm6dsvTaggedFifoParsing {
 		assertEquals(150, uncal(magOjc, SensorLSM6DSV.ObjectClusterSensorName.LIS2MDL_MAG_Z), 0.001);
 		assertTrue(Double.isNaN(uncal(magOjc, SensorLSM6DSV.ObjectClusterSensorName.LSM6DSV_ACC_X)));
 		assertTrue(Double.isNaN(uncal(magOjc, SensorLSM6DSV.ObjectClusterSensorName.LSM6DSV_GYRO_X)));
+
+		// CAL assertions - regression-locks the calibration constants against
+		// LITERAL expected values (the gyro sensitivity was ~12.8% wrong before the
+		// DEV-793 round-2 review fix; deriving the expectation from the class
+		// constants would defeat the lock). Defaults: accel +/-4 g = 835.3517
+		// LSB/(m/s^2); gyro +/-500 dps = 57.142857 LSB/dps (ST 17.50 mdps/LSB).
+		assertEquals(100 / 835.3517, cal(aligned0, SensorLSM6DSV.ObjectClusterSensorName.LSM6DSV_ACC_X), 0.0001);
+		assertEquals(-200 / 835.3517, cal(aligned0, SensorLSM6DSV.ObjectClusterSensorName.LSM6DSV_ACC_Y), 0.0001);
+		assertEquals(10 / 57.142857143, cal(aligned0, SensorLSM6DSV.ObjectClusterSensorName.LSM6DSV_GYRO_X), 0.0001);
+		assertEquals(-20 / 57.142857143, cal(aligned0, SensorLSM6DSV.ObjectClusterSensorName.LSM6DSV_GYRO_Y), 0.0001);
 	}
 
 	/** Gyro-only: gyro acts as the aligned reference stream. */


### PR DESCRIPTION
Part of [DEV-793](https://shimmersensing.atlassian.net/browse/DEV-793) — 2nd-generation Verisense (SR68-9 "Pulse+", payload design v9 / FW v2.00.004) LSM6DSV IMU support in the Java driver.

## Changes (ShimmerDriver)
- New `SensorLSM6DSV` — accel + gyro + LIS2MDL mag (read via the LSM6DSV sensor hub), nominal calibration.
- `VerisenseDevice`: v13/36-byte config-header detection, gen-2 enabled-sensor detection (GEN_CFG_0 accel2/gyro + GEN_CFG_3 mag), variable-length tagged-FIFO parse path (accel/gyro aligned; mag emitted as its own async ObjectCluster stream), `getSamplingRateShimmer` + `Sensor config:` header support.
- `Configuration` (LSM6DSV SENSOR_IDs / SensorBitmap / compatibility), `AsmBinaryFileConstants` (GEN_CFG_3 index), `DataBlockDetails` (DATABLOCK_SENSOR_ID), `PayloadContentsDetails` (v13 header size).

## Testing
Drives the 5 gen-2 IMU tests in companion PR ShimmerResearch/ASM_PC#342 to green — accel ~1 g, gyro ~0 dps, mag ~32 uT verified against real SR68-9 recordings.

## Related
- Companion PR: ShimmerResearch/ASM_PC#342
- Firmware fix: `verisense-firmware` branch `DEV-604_LSM6DSV_config_and_streaming`

Generated with Claude Code


[DEV-793]: https://shimmersensing.atlassian.net/browse/DEV-793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ