### PR TITLE
DEV-875 Generalise the non-wear derived-sensor bit to the LSM6DS family (LSM6DSX)

### DIFF
--- a/ShimmerDriver/src/main/java/com/shimmerresearch/driver/Configuration.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/driver/Configuration.java
@@ -2651,7 +2651,14 @@ public class Configuration {
 		
 		public class DerivedSensorsBitMask {
 			public final static int NON_WEAR_DETECTION_LIS2DW12	= (1 << 0);
-			public final static int NON_WEAR_DETECTION_LSM6DS3	= (1 << 1);
+			/** Covers the LSM6DS IMU family: LSM6DS3 (first-generation) and LSM6DSV
+			 * (second-generation SR68-9/10, SR61-5/6). The two never coexist on one
+			 * board so a single bit is unambiguous. */
+			public final static int NON_WEAR_DETECTION_LSM6DSX	= (1 << 1);
+			/** @deprecated renamed to {@link #NON_WEAR_DETECTION_LSM6DSX} when non-wear
+			 * detection was extended to the LSM6DSV (DEV-875). */
+			@Deprecated
+			public final static int NON_WEAR_DETECTION_LSM6DS3	= NON_WEAR_DETECTION_LSM6DSX;
 			public final static int PPG_TO_HR_RED_LED		= (1 << 2);
 			public final static int PPG_TO_HR_IR_LED		= (1 << 3);
 			public final static int PPG_TO_HR_GREEN_LED		= (1 << 4);

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/driver/Configuration.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/driver/Configuration.java
@@ -2655,8 +2655,10 @@ public class Configuration {
 			 * (second-generation SR68-9/10, SR61-5/6). The two never coexist on one
 			 * board so a single bit is unambiguous. */
 			public final static int NON_WEAR_DETECTION_LSM6DSX	= (1 << 1);
-			/** @deprecated renamed to {@link #NON_WEAR_DETECTION_LSM6DSX} when non-wear
-			 * detection was extended to the LSM6DSV (DEV-875). */
+			/**
+			 * @deprecated Renamed to {@link #NON_WEAR_DETECTION_LSM6DSX} when non-wear
+			 * detection was extended to the LSM6DSV (DEV-875).
+			 */
 			@Deprecated
 			public final static int NON_WEAR_DETECTION_LSM6DS3	= NON_WEAR_DETECTION_LSM6DSX;
 			public final static int PPG_TO_HR_RED_LED		= (1 << 2);


### PR DESCRIPTION
Stacked on #277 — merge that first, then retarget/merge this. Jira: [DEV-875](https://shimmersensing.atlassian.net/browse/DEV-875).

Renames `DerivedSensorsBitMask.NON_WEAR_DETECTION_LSM6DS3` to `NON_WEAR_DETECTION_LSM6DSX` (same bit, `1<<1`) so a single non-wear algorithm variant can cover both the gen-1 LSM6DS3 and the gen-2 LSM6DSV:

- The two IMUs never coexist on one board (gen-1 vs gen-2), so the shared bit is unambiguous; the LIS2DW12 keeps its own bit 0.
- The Verisense derived-sensors mask is an in-process enable key that is **never persisted** — payload/op-config bytes carry the enabled-sensors bitmap only, the cloud RDS stores non-wear results without a bitmask column, and the frozen "must not change" contract applies only to the separate `Shimmer3` namespace (infomem/SD headers).
- A `@Deprecated` alias keeps source compatibility for consumers of the published jar.

The algorithm-side change (merged `ALGO_NON_WEAR_DETECTION_LSM6DSX` with `SENSOR_CHECK_METHOD.ANY`) is in the companion ASM_PC PR on branch `DEV-875_lsm6dsv_nonwear`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DEV-875]: https://shimmersensing.atlassian.net/browse/DEV-875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ