### PR TITLE
DEV-895 Stop per-device reader threads busy-spinning when idle

### DIFF
--- a/ShimmerDriver/src/main/java/com/shimmerresearch/bluetooth/ShimmerBluetooth.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/bluetooth/ShimmerBluetooth.java
@@ -581,19 +581,26 @@ public abstract class ShimmerBluetooth extends ShimmerObject implements Serializ
 		int count=0;
 		public void run() {
 			while (!stop) {
-				if(!mABQPacketByeArray.isEmpty()){
+				RawBytePacketWithPCTimeStamp rbp = null;
+				try {
+					// Blocks (with a timeout) instead of busy-spinning on isEmpty() while idle.
+					// The timeout ensures the stop flag is still checked periodically.
+					rbp = mABQPacketByeArray.poll(100, TimeUnit.MILLISECONDS);
+				} catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+				}
+				if(rbp!=null){
 					count++;
 					if(count%1000==0){
 						consolePrintLn("Queue Size: " + mABQPacketByeArray.size());
 						printLogDataForDebugging("Queue Size: " + mABQPacketByeArray.size() + "\n");
 					}
-					RawBytePacketWithPCTimeStamp rbp = mABQPacketByeArray.remove();
 //					buildAndSendMsg(rbp.mDataArray, FW_TYPE_BT, false, rbp.mSystemTimeStamp);
 					buildAndSendMsg(rbp.mDataArray, COMMUNICATION_TYPE.BLUETOOTH, false, rbp.mSystemTimeStamp);
 				}
-			} 
-		} 
-	} 
+			}
+		}
+	}
 	
 	//region --------- BLUETOOH STACK --------- 
 	
@@ -603,9 +610,11 @@ public abstract class ShimmerBluetooth extends ShimmerObject implements Serializ
 		
 		public void run() {
 			while(!stop) {
+				boolean didWork = false;
 				//In-Shimmer Test here
 				if(InShimmerTest) {
 					if (bytesAvailableToBeRead()) {
+					didWork = true;
 					byte[] data = readBytes(availableBytes());
 					if (data!=null) {
 						if (data.length>0) {
@@ -619,29 +628,43 @@ public abstract class ShimmerBluetooth extends ShimmerObject implements Serializ
 				else {
 					if (mDummyRead) {
 						performDummyRead();
+						didWork = true;
 					}
-	
+
 					// Process Instruction on stack. is an instruction running? if not proceed
 					if(!isInstructionStackLock()){
-						processNextInstruction();
+						if(processNextInstruction()){
+							didWork = true;
+						}
 					}
-	
+
 					if(mIsStreaming){
 						processWhileStreaming();
+						didWork = true;
 					}
 					else if(bytesAvailableToBeRead()){
+						didWork = true;
 						if(mWaitForAck) {
 							processNotStreamingWaitForAck();
-						} 
+						}
 						else if(mWaitForResponse) {
 							processNotStreamingWaitForResp();
-						} 
-						
+						}
+
 						processBytesAvailableAndInstreamSupported();
-	
+
 					}
 				}
-				
+
+				if(!didWork){
+					// Nothing useful happened this iteration (idle, not streaming, no pending
+					// instructions/bytes) - avoid busy-spinning and pegging a CPU core.
+					try {
+						Thread.sleep(2);
+					} catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+					}
+				}
 			}
 		}
 		
@@ -674,10 +697,11 @@ public abstract class ShimmerBluetooth extends ShimmerObject implements Serializ
 			mDummyReadStarted = false;
 		}
 		
-		private void processNextInstruction() {
+		/** @return true if an instruction was found and processed (i.e. useful work was done) */
+		private boolean processNextInstruction() {
 			// check instruction stack, are there any other instructions left to be executed?
 			//checkAndRemoveFirstInstructionIfNull();
-			
+
 			byte[] insBytes = getInstruction();
 			if (insBytes!=null){
 					mCurrentCommand=insBytes[0];
@@ -754,14 +778,16 @@ public abstract class ShimmerBluetooth extends ShimmerObject implements Serializ
 					
 					
 					mTransactionCompleted=false;
+				return true;
 			} else {
 				if (!mIsStreaming && !bytesAvailableToBeRead()){
 					threadSleep(50);
 				}
+				return false;
 			}
 		}
-		
-		/** Process ACK from a GET or SET command while not streaming */ 
+
+		/** Process ACK from a GET or SET command while not streaming */
 		private void processNotStreamingWaitForAck() {
 			//JC TEST:: IMPORTANT TO REMOVE // This is to simulate packet loss 
 			/*

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/bluetooth/ShimmerBluetooth.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/bluetooth/ShimmerBluetooth.java
@@ -580,7 +580,7 @@ public abstract class ShimmerBluetooth extends ShimmerObject implements Serializ
 		public boolean stop = false;
 		int count=0;
 		public void run() {
-			while (!stop) {
+			while (!stop && !Thread.currentThread().isInterrupted()) {
 				RawBytePacketWithPCTimeStamp rbp = null;
 				try {
 					// Blocks (with a timeout) instead of busy-spinning on isEmpty() while idle.
@@ -609,7 +609,7 @@ public abstract class ShimmerBluetooth extends ShimmerObject implements Serializ
 		public boolean stop = false;
 		
 		public void run() {
-			while(!stop) {
+			while(!stop && !Thread.currentThread().isInterrupted()) {
 				boolean didWork = false;
 				//In-Shimmer Test here
 				if(InShimmerTest) {

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/comms/radioProtocol/LiteProtocol.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/comms/radioProtocol/LiteProtocol.java
@@ -255,6 +255,13 @@ public class LiteProtocol extends AbstractCommsProtocol{
 	private void stopIoThread() {
 		if(mIOThread!=null){
 			mIOThread.stop=true;
+			// Bounded wait for the thread to actually exit its loop before dropping the
+			// reference, without risking blocking indefinitely.
+			try {
+				mIOThread.join(2000);
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
 			mIOThread = null;
 		}
 	}
@@ -266,36 +273,52 @@ public class LiteProtocol extends AbstractCommsProtocol{
 		
 		public synchronized void run() {
 			while (!stop) {
+				boolean didWork = false;
 				try {
 					// Process Instruction on stack. is an instruction running? if not proceed
 					if(!isInstructionStackLock()){
-						processNextInstruction();
+						if(processNextInstruction()){
+							didWork = true;
+						}
 					}
-				
+
 					if(isStreaming()){
 						processWhileStreaming();
+						didWork = true;
 					}
 					else if(bytesAvailableToBeRead()){
+						didWork = true;
 						if(mWaitForAck) {
 							processNotStreamingWaitForAck();
-						} 
+						}
 						else if(mWaitForResponse) {
 							processNotStreamingWaitForResp();
-						} 
-						
+						}
+
 						processBytesAvailableAndInstreamSupported();
 					}
 				} catch (ShimmerException dE) {
 //					stop=true;
-					
+
 					killConnection(dE);
 //					e.printStackTrace();
 					//TODO send event up the ladder
 				}
-			} 
-		} 
-		
-		private void processNextInstruction() throws ShimmerException {
+
+				if(!didWork){
+					// Nothing useful happened this iteration (idle, not streaming, no pending
+					// instructions/bytes) - avoid busy-spinning and pegging a CPU core.
+					try {
+						Thread.sleep(2);
+					} catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+					}
+				}
+			}
+		}
+
+		/** @return true if an instruction was found and processed (i.e. useful work was done) */
+		private boolean processNextInstruction() throws ShimmerException {
 			// check instruction stack, are there any other instructions left to be executed?
 			if(!getListofInstructions().isEmpty()) {
 				if(getListofInstructions().get(0)==null) {
@@ -387,16 +410,18 @@ public class LiteProtocol extends AbstractCommsProtocol{
 							}
 						}*/
 					}
-					
-					
+
+
 					mTransactionCompleted=false;
+					return true;
 				}
-			} 
+			}
 			else {
 				if (!isStreaming() && !bytesAvailableToBeRead()){
 					threadSleep(50);
 				}
 			}
+			return false;
 		}
 
 		private void processWhileStreaming() throws ShimmerException {

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/comms/radioProtocol/LiteProtocol.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/comms/radioProtocol/LiteProtocol.java
@@ -256,11 +256,15 @@ public class LiteProtocol extends AbstractCommsProtocol{
 		if(mIOThread!=null){
 			mIOThread.stop=true;
 			// Bounded wait for the thread to actually exit its loop before dropping the
-			// reference, without risking blocking indefinitely.
-			try {
-				mIOThread.join(2000);
-			} catch (InterruptedException e) {
-				Thread.currentThread().interrupt();
+			// reference. Guard against the self-join case: killConnection() can reach here
+			// synchronously from within IOThread.run()'s catch block (error-driven teardown),
+			// and a thread joining itself would just burn the full timeout.
+			if(Thread.currentThread() != mIOThread){
+				try {
+					mIOThread.join(2000);
+				} catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+				}
 			}
 			mIOThread = null;
 		}
@@ -271,8 +275,13 @@ public class LiteProtocol extends AbstractCommsProtocol{
 		byte[] byteBuffer = {0};
 		public boolean stop = false;
 		
-		public synchronized void run() {
-			while (!stop) {
+		/*
+		 * Deliberately NOT synchronized: Thread.join() locks this same Thread
+		 * instance, so a synchronized run() would block external stopIoThread()
+		 * callers on monitor entry (with no timeout) until the loop exits.
+		 */
+		public void run() {
+			while (!stop && !Thread.currentThread().isInterrupted()) {
 				boolean didWork = false;
 				try {
 					// Process Instruction on stack. is an instruction running? if not proceed

--- a/ShimmerDriverPC/src/main/java/com/shimmerresearch/pcDriver/ShimmerPC.java
+++ b/ShimmerDriverPC/src/main/java/com/shimmerresearch/pcDriver/ShimmerPC.java
@@ -608,13 +608,23 @@ public class ShimmerPC extends ShimmerBluetooth implements Serializable{
 			if (mIOThread != null) {
 				mIOThread.stop = true;
 				
-				// Closing serial port before before thread is finished stopping throws an error so waiting here
-				while(mIOThread != null && mIOThread.isAlive());
+				// Closing serial port before before thread is finished stopping throws an error so waiting here.
+				// Bounded join instead of an empty-body busy-wait, so this can't block indefinitely.
+				try {
+					mIOThread.join(2000);
+				} catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+				}
 
 				mIOThread = null;
-				
+
 				if(mUseProcessingThread){
 					mPThread.stop = true;
+					try {
+						mPThread.join(2000);
+					} catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+					}
 					mPThread = null;
 				}
 			}

--- a/ShimmerDriverPC/src/main/java/com/shimmerresearch/pcDriver/ShimmerPC.java
+++ b/ShimmerDriverPC/src/main/java/com/shimmerresearch/pcDriver/ShimmerPC.java
@@ -610,10 +610,15 @@ public class ShimmerPC extends ShimmerBluetooth implements Serializable{
 				
 				// Closing serial port before before thread is finished stopping throws an error so waiting here.
 				// Bounded join instead of an empty-body busy-wait, so this can't block indefinitely.
-				try {
-					mIOThread.join(2000);
-				} catch (InterruptedException e) {
-					Thread.currentThread().interrupt();
+				// Skip the join when closeConnection() is reached from the IOThread itself
+				// (connectionLost() fires on it when the serial port errors mid-read/write) -
+				// a self-join can never succeed and would just burn the full timeout.
+				if(Thread.currentThread() != mIOThread){
+					try {
+						mIOThread.join(2000);
+					} catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+					}
 				}
 
 				mIOThread = null;


### PR DESCRIPTION
## Summary

Each connected Shimmer device previously kept 1–2 threads spinning in tight `while(!stop)` loops with no sleep, pegging up to a CPU core per device even when fully idle (not streaming, no commands in flight). Part of the cross-repo `DEV-895` resource-usage work (companion PRs in ConsensysApps and Shimmer-Advance-API).

## Changes

- **`ShimmerBluetooth.IOThread`** and **`LiteProtocol.IOThread`**: track whether an iteration did useful work (instruction processed, actively streaming, or bytes read); sleep 2 ms only when it didn't. Streaming and pending-work paths are unchanged — no added latency when there is real work to do. `processNextInstruction()` (private inner-class method) now returns `boolean` to report whether an instruction was processed.
- **`ShimmerBluetooth.ProcessingThread`**: replaced the `isEmpty()` spin on the packet queue with a blocking `ArrayBlockingQueue.poll(100 ms)`, so the thread parks while idle; buffer/count/logging logic unchanged.
- **Teardown busy-waits** replaced with bounded joins: `ShimmerPC.closeConnection()` (empty-body `while(mIOThread.isAlive());` spin → `join(2000)`, plus a new bounded join for `mPThread`, which previously got no wait at all before its reference was dropped) and `LiteProtocol.stopIoThread()` (`join(2000)` before nulling).

## Testing

- `ShimmerDriver` and `ShimmerDriverPC` `gradle compileJava` both pass (exit 0, pre-existing warnings only).
- Needs manual verification with hardware: idle connected devices should no longer consume a core; streaming throughput/latency should be unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JjgNkS6wtPkQUdK3KdHVdN

---
_Generated by [Claude Code](https://claude.ai/code/session_01JjgNkS6wtPkQUdK3KdHVdN)_