### PR TITLE
DEV-896 Fix Live Data plot stutter: O(1) monotonic-X trace bounds, batched chart locking

### DIFF
--- a/ShimmerDriverPC/src/main/java/com/shimmerresearch/guiUtilities/plot/BasicPlotManagerPC.java
+++ b/ShimmerDriverPC/src/main/java/com/shimmerresearch/guiUtilities/plot/BasicPlotManagerPC.java
@@ -2008,6 +2008,12 @@ public class BasicPlotManagerPC extends AbstractPlotManager {
 				//per-point synchronized(chart) inside addPoint() is free while we hold this outer lock.
 				//The batch is bounded by the number of plotted traces, so the lock hold stays short.
 				//Falls back to the already-held mListofPropertiestoPlot monitor if no chart is set yet.
+				//IMPORTANT (lock ordering): snapshot mListofTraces BEFORE taking the chart monitor.
+				//Other threads (e.g. clearAllDataBuffer, trace resizing) hold the mListofTraces monitor
+				//while calling chart-locking trace mutators (removeAllPoints/setMaxSize), i.e.
+				//mListofTraces -> chart. Touching mListofTraces while holding the chart monitor here
+				//would be the reverse order and a real deadlock cycle.
+				ITrace2D[] tracesSnapshot = mListofTraces.toArray(new ITrace2D[0]);
 				Object chartMonitor = (mChart != null) ? (Object)mChart : (Object)mListofPropertiestoPlot;
 				synchronized(chartMonitor){
 				while (entries.hasNext()) {
@@ -2068,10 +2074,10 @@ public class BasicPlotManagerPC extends AbstractPlotManager {
 							continue;
 						}
 
-						if (indexOfTrace>mListofTraces.size()){
+						if (indexOfTrace>tracesSnapshot.length){
 							throw new Exception("Trace does not exist: (" + traceName + ")");
 						}
-						ITrace2D currentTrace = mListofTraces.get(indexOfTrace); 
+						ITrace2D currentTrace = tracesSnapshot[indexOfTrace]; 
 						//utilShimmer.consolePrintErrLn(currentTrace.getMaxY());
 
 						mCurrentXValue = xData;

--- a/ShimmerDriverPC/src/main/java/com/shimmerresearch/guiUtilities/plot/BasicPlotManagerPC.java
+++ b/ShimmerDriverPC/src/main/java/com/shimmerresearch/guiUtilities/plot/BasicPlotManagerPC.java
@@ -1645,7 +1645,56 @@ public class BasicPlotManagerPC extends AbstractPlotManager {
 		}
 		trace.addPoint(xData, yData);
 	}
-	
+
+	/** DEV-896: Max points added per single chart-monitor acquisition in {@link #addPointsToTrace}.
+	 * Bounds how long the batch can hold the chart lock so a large burst can't monopolise the EDT. */
+	private static final int POINT_BATCH_MAX = 256;
+
+	/**
+	 * DEV-896: Batch variant of {@link #addPointToTrace(ITrace2D, double, double)}. Adds many
+	 * points to a single trace while acquiring the chart monitor once per (bounded) chunk rather
+	 * than once per point. {@code ATrace2D.addPoint()} synchronizes on the chart
+	 * ({@code trace.getRenderer()}) - the same monitor {@code Chart2D.paintComponent()} holds - so
+	 * adding N points individually took the monitor N times and starved the Swing EDT. Java monitors
+	 * are reentrant, so {@code addPoint()}'s internal {@code synchronized(chart)} is free while we
+	 * hold the outer lock. Behaviour per point is identical to {@link #addPointToTrace}.
+	 */
+	public void addPointsToTrace(ITrace2D trace, double[] xData, double[] yData){
+		if(xData == null || yData == null){
+			return;
+		}
+		addPointsToTrace(trace, xData, yData, 0, Math.min(xData.length, yData.length));
+	}
+
+	/**
+	 * DEV-896: See {@link #addPointsToTrace(ITrace2D, double[], double[])}. Adds points
+	 * {@code [fromIndex, toIndex)} from the given arrays.
+	 */
+	public void addPointsToTrace(ITrace2D trace, double[] xData, double[] yData, int fromIndex, int toIndex){
+		if(trace == null || xData == null || yData == null){
+			return;
+		}
+		int end = Math.min(toIndex, Math.min(xData.length, yData.length));
+		int i = Math.max(0, fromIndex);
+		//trace.getRenderer() returns the Chart2D the trace was added to (null until then); it is the
+		//exact monitor ATrace2D.addPoint() locks, so holding it makes the per-point locks reentrant.
+		Chart2D chart = trace.getRenderer();
+		while(i < end){
+			int chunkEnd = Math.min(i + POINT_BATCH_MAX, end);
+			if(chart != null){
+				synchronized(chart){
+					for(; i < chunkEnd; i++){
+						addPointToTrace(trace, xData[i], yData[i]);
+					}
+				}
+			} else {
+				for(; i < chunkEnd; i++){
+					addPointToTrace(trace, xData[i], yData[i]);
+				}
+			}
+		}
+	}
+
 	public CircularFifoBuffer getCirculurBufferedTraceData(String traceName){
 		CircularFifoBuffer circularFifoBuffer = mMapOfCirculurBufferedTraceDataPoints.get(traceName);
 		if(circularFifoBuffer != null){ 
@@ -1869,10 +1918,9 @@ public class BasicPlotManagerPC extends AbstractPlotManager {
 						if(results.length==2 && results[0].length>startBin){
 							
 							trace.removeAllPoints();
-							
-							for(int x=startBin;x<results[0].length;x++){
-								addPointToTrace(trace, results[0][x], results[1][x]);
-							}
+
+							//DEV-896: batch the FFT bins into one chart-monitor acquisition per chunk
+							addPointsToTrace(trace, results[0], results[1], startBin, results[0].length);
 						}
 					}
 					
@@ -1951,8 +1999,17 @@ public class BasicPlotManagerPC extends AbstractPlotManager {
 			synchronized(mListofPropertiestoPlot){
 				Iterator <String[]> entries = mListofPropertiestoPlot.iterator();
 				int indexOfTrace = 0;
-				boolean isDummyPointAddedToFillTrace = false; 
-				
+				boolean isDummyPointAddedToFillTrace = false;
+
+				//DEV-896: Acquire the chart monitor once for this whole multi-trace update instead
+				//of once per trace inside ATrace2D.addPoint(). addPoint() synchronizes on the chart
+				//(trace.getRenderer()) - the same monitor Chart2D.paintComponent() holds - so grabbing
+				//it once per sample was starving the Swing EDT. Java monitors are reentrant, so the
+				//per-point synchronized(chart) inside addPoint() is free while we hold this outer lock.
+				//The batch is bounded by the number of plotted traces, so the lock hold stays short.
+				//Falls back to the already-held mListofPropertiestoPlot monitor if no chart is set yet.
+				Object chartMonitor = (mChart != null) ? (Object)mChart : (Object)mListofPropertiestoPlot;
+				synchronized(chartMonitor){
 				while (entries.hasNext()) {
 					String[] props = entries.next();
 					
@@ -2067,6 +2124,7 @@ public class BasicPlotManagerPC extends AbstractPlotManager {
 					}
 					indexOfTrace++;
 				}
+				} //DEV-896: release the chart monitor once the whole multi-trace update is done
 				if(isDummyPointAddedToFillTrace) {
 					isFirstPointOnFillTrace = false;
 				}

--- a/ShimmerDriverPC/src/main/java/com/shimmerresearch/guiUtilities/plot/BasicPlotManagerPC.java
+++ b/ShimmerDriverPC/src/main/java/com/shimmerresearch/guiUtilities/plot/BasicPlotManagerPC.java
@@ -347,7 +347,7 @@ public class BasicPlotManagerPC extends AbstractPlotManager {
 	}
 
 	private ITrace2D createNormalTrace(int plotMaxSize) {
-		Trace2DLtd trace = new Trace2DLtd(plotMaxSize);
+		Trace2DLtd trace = new Trace2DLtdMonotonicX(plotMaxSize); //DEV-896: monotonic-X trace avoids O(n) minX rescans per sample
 		BasicStroke stroke = ((BasicStroke)trace.getStroke());
 		BasicStroke newStroke = new BasicStroke(DEFAULT_LINE_THICKNESS,stroke.getEndCap(),stroke.getLineJoin(),stroke.getMiterLimit(),stroke.getDashArray(),stroke.getDashPhase());
 		trace.setStroke(newStroke);
@@ -355,7 +355,7 @@ public class BasicPlotManagerPC extends AbstractPlotManager {
 	}
 
 	private ITrace2D createBarTrace(Chart2D chart, int plotMaxSize) {
-		ITrace2D trace = new Trace2DLtd(plotMaxSize);
+		ITrace2D trace = new Trace2DLtdMonotonicX(plotMaxSize); //DEV-896: monotonic-X trace avoids O(n) minX rescans per sample
 		trace.setTracePainter(new TracePainterVerticalBar(chart));
 		return trace;
 	}
@@ -369,7 +369,7 @@ public class BasicPlotManagerPC extends AbstractPlotManager {
 	 */
 	private ITrace2D addSignalToExistingChartInternal(String[] signal, int plotMaxSize, Color color) throws Exception{
 		if (!checkIfPropertyExist(signal)){
-			ITrace2D trace = new Trace2DLtd(plotMaxSize);
+			ITrace2D trace = new Trace2DLtdMonotonicX(plotMaxSize); //DEV-896: monotonic-X trace avoids O(n) minX rescans per sample
 			mChart.addTrace(trace);
 			
 			mListofTraces.add(trace);

--- a/ShimmerDriverPC/src/main/java/com/shimmerresearch/guiUtilities/plot/Trace2DLtdMonotonicX.java
+++ b/ShimmerDriverPC/src/main/java/com/shimmerresearch/guiUtilities/plot/Trace2DLtdMonotonicX.java
@@ -1,0 +1,142 @@
+package com.shimmerresearch.guiUtilities.plot;
+
+import info.monitorenter.gui.chart.ITracePoint2D;
+import info.monitorenter.gui.chart.traces.Trace2DLtd;
+
+/**
+ * DEV-896: A bounded (ring-buffer backed) trace optimised for the live time-series
+ * streaming case where the X value is monotonically (non-decreasing) increasing.
+ *
+ * <p>Problem being solved: {@code Trace2DLtd.addPointInternal()} maintains the trace
+ * min/max by, on every eviction of the oldest ring-buffer element, checking whether the
+ * evicted point held an extreme and if so running a full linear rescan
+ * ({@code ATrace2D.minXSearch()} / {@code maxXSearch()} / {@code minYSearch()} /
+ * {@code maxYSearch()}) over the whole buffer. For a time-series plot X is strictly
+ * increasing, so the evicted (oldest) point ALWAYS holds the minimum X, which triggers an
+ * O(buffer) {@code minXSearch()} on essentially every sample in steady state. Because
+ * {@code ATrace2D.addPoint()} does that work while holding {@code synchronized(chart)}
+ * (the same monitor {@code Chart2D.paintComponent()} uses), the data thread starves the
+ * Swing EDT and the plot stutters.</p>
+ *
+ * <p>Fix: when the ring buffer is known to be sorted ascending by X, the minimum X is
+ * simply the oldest buffer element and the maximum X the youngest, both O(1). We override
+ * {@code minXSearch()} / {@code maxXSearch()} to use those accessors on the fast path and
+ * fall back to the (correct) superclass scan otherwise.</p>
+ *
+ * <p>Correctness / robustness:</p>
+ * <ul>
+ *   <li>We only take the O(1) path when the buffer is guaranteed sorted ascending by X.
+ *       That guarantee holds iff the most recent {@code size()} insertions all had
+ *       non-decreasing X, because a ring buffer holds exactly the most recent
+ *       {@code size()} insertions. We track the length of the current run of consecutive
+ *       non-decreasing-X insertions ({@link #mAscendingRunLength}); when it is at least the
+ *       current buffer element count the whole buffer content is that non-decreasing suffix,
+ *       hence sorted.</li>
+ *   <li>If X ever arrives out of order (e.g. plot re-fed on rewind / replay / device reset)
+ *       the run is reset and we fall back to the superclass scans until enough monotonic
+ *       samples have refilled the buffer, so the displayed range is always exact.</li>
+ *   <li>Y is left entirely to the superclass. For random Y the oldest point holds the Y
+ *       extreme only ~2/size of the time, so the Y rescan cost is already amortised O(1);
+ *       optimising it is unnecessary and would risk the displayed Y auto-scale.</li>
+ *   <li>{@code setMaxSize(int)} is {@code final} in {@code Trace2DLtd} so it cannot be
+ *       overridden, but no reset hook is needed: {@link #isBufferSortedAscendingByX()} reads
+ *       the live {@code m_buffer.size()} each call, so growing the buffer transparently
+ *       disables the fast path until it refills and shrinking (which only discards the
+ *       oldest, smallest-X elements) keeps the buffer sorted.</li>
+ * </ul>
+ *
+ * <p>Externally this class behaves identically to {@code Trace2DLtd} (same bounds, same
+ * property-change events, same {@code setMaxSize} semantics); it only removes the redundant
+ * O(n) X rescans. It extends {@code Trace2DLtd} so existing
+ * {@code ((Trace2DLtd)trace).setMaxSize(...)} / {@code .iterator()} casts keep working.</p>
+ */
+public class Trace2DLtdMonotonicX extends Trace2DLtd {
+
+	/** X value of the most recently inserted point, used to detect non-decreasing X. */
+	private double mLastX = Double.NaN;
+
+	/**
+	 * Number of consecutive insertions (ending at the most recent one) whose X was
+	 * non-decreasing. When this is {@code >= m_buffer.size()} the entire current buffer
+	 * content was produced by a non-decreasing run and is therefore sorted ascending by X.
+	 */
+	private long mAscendingRunLength = 0L;
+
+	public Trace2DLtdMonotonicX() {
+		super();
+	}
+
+	public Trace2DLtdMonotonicX(int maxSize) {
+		super(maxSize);
+	}
+
+	public Trace2DLtdMonotonicX(int maxSize, String name) {
+		super(maxSize, name);
+	}
+
+	public Trace2DLtdMonotonicX(String name) {
+		super(name);
+	}
+
+	/**
+	 * @return {@code true} when the backing ring buffer is currently guaranteed to be sorted
+	 *         ascending by X, i.e. the most recent {@code size()} insertions were all
+	 *         non-decreasing in X. Reads the live buffer size so it stays correct across
+	 *         {@code setMaxSize(int)}.
+	 */
+	private boolean isBufferSortedAscendingByX() {
+		if (m_buffer == null || m_buffer.isEmpty()) {
+			return false;
+		}
+		return mAscendingRunLength >= m_buffer.size();
+	}
+
+	@Override
+	protected boolean addPointInternal(ITracePoint2D p) {
+		double x = p.getX();
+		if (Double.isNaN(mLastX) || x >= mLastX) {
+			// Non-decreasing X: extend the ascending run (cap to avoid overflow; any value
+			// above the buffer size already means "fully sorted").
+			if (mAscendingRunLength < Long.MAX_VALUE) {
+				mAscendingRunLength++;
+			}
+		} else {
+			// X went backwards: the buffer is no longer sorted. This incoming point starts a
+			// new ascending run of length 1. The fast path resumes once the run refills the
+			// buffer; until then the superclass scans keep the range exact.
+			mAscendingRunLength = 1L;
+		}
+		mLastX = x;
+		// Delegates to Trace2DLtd, which on eviction virtually dispatches to our overridden
+		// minXSearch()/maxXSearch() below (and to the unchanged Y searches).
+		return super.addPointInternal(p);
+	}
+
+	@Override
+	protected void minXSearch() {
+		if (isBufferSortedAscendingByX()) {
+			try {
+				// Oldest element holds the smallest X when the buffer is sorted ascending.
+				m_minX = m_buffer.getOldest().getX();
+				return;
+			} catch (RuntimeException e) {
+				// Buffer emptied concurrently / unexpected state: fall back to the safe scan.
+			}
+		}
+		super.minXSearch();
+	}
+
+	@Override
+	protected void maxXSearch() {
+		if (isBufferSortedAscendingByX()) {
+			try {
+				// Youngest element holds the largest X when the buffer is sorted ascending.
+				m_maxX = m_buffer.getYoungest().getX();
+				return;
+			} catch (RuntimeException e) {
+				// Fall back to the safe scan.
+			}
+		}
+		super.maxXSearch();
+	}
+}

--- a/ShimmerDriverPC/src/main/java/com/shimmerresearch/guiUtilities/plot/Trace2DLtdMonotonicX.java
+++ b/ShimmerDriverPC/src/main/java/com/shimmerresearch/guiUtilities/plot/Trace2DLtdMonotonicX.java
@@ -40,9 +40,10 @@ import info.monitorenter.gui.chart.traces.Trace2DLtd;
  *       optimising it is unnecessary and would risk the displayed Y auto-scale.</li>
  *   <li>{@code setMaxSize(int)} is {@code final} in {@code Trace2DLtd} so it cannot be
  *       overridden, but no reset hook is needed: {@link #isBufferSortedAscendingByX()} reads
- *       the live {@code m_buffer.size()} each call, so growing the buffer transparently
- *       disables the fast path until it refills and shrinking (which only discards the
- *       oldest, smallest-X elements) keeps the buffer sorted.</li>
+ *       the live {@code m_buffer.size()} each call. Growing leaves the element count and
+ *       ordering unchanged (a sorted buffer stays sorted, so the fast path validly stays
+ *       available); shrinking only discards the oldest, smallest-X elements, which also
+ *       keeps the buffer sorted.</li>
  * </ul>
  *
  * <p>Externally this class behaves identically to {@code Trace2DLtd} (same bounds, same
@@ -52,15 +53,21 @@ import info.monitorenter.gui.chart.traces.Trace2DLtd;
  */
 public class Trace2DLtdMonotonicX extends Trace2DLtd {
 
-	/** X value of the most recently inserted point, used to detect non-decreasing X. */
-	private double mLastX = Double.NaN;
+	/**
+	 * X value of the most recently inserted point, used to detect non-decreasing X.
+	 * Volatile: normal updates happen under the chart+trace locks (inside addPoint), but the
+	 * conservative resets in {@link #firePointChanged} may run outside them; volatile prevents
+	 * a torn 64-bit write from ever spuriously enabling the fast path. All unlocked writes are
+	 * resets, which can only (safely) disable it.
+	 */
+	private volatile double mLastX = Double.NaN;
 
 	/**
 	 * Number of consecutive insertions (ending at the most recent one) whose X was
 	 * non-decreasing. When this is {@code >= m_buffer.size()} the entire current buffer
 	 * content was produced by a non-decreasing run and is therefore sorted ascending by X.
 	 */
-	private long mAscendingRunLength = 0L;
+	private volatile long mAscendingRunLength = 0L;
 
 	public Trace2DLtdMonotonicX() {
 		super();
@@ -94,7 +101,12 @@ public class Trace2DLtdMonotonicX extends Trace2DLtd {
 	@Override
 	protected boolean addPointInternal(ITracePoint2D p) {
 		double x = p.getX();
-		if (Double.isNaN(mLastX) || x >= mLastX) {
+		if (Double.isNaN(x)) {
+			// NaN X (jchart2d's discontinuation marker) breaks any ordering guarantee for as
+			// long as it stays in the buffer: contribute nothing to the ascending run, so the
+			// fast path can only resume once a full buffer of post-NaN points has evicted it.
+			mAscendingRunLength = 0L;
+		} else if (Double.isNaN(mLastX) || x >= mLastX) {
 			// Non-decreasing X: extend the ascending run (cap to avoid overflow; any value
 			// above the buffer size already means "fully sorted").
 			if (mAscendingRunLength < Long.MAX_VALUE) {
@@ -110,6 +122,22 @@ public class Trace2DLtdMonotonicX extends Trace2DLtd {
 		// Delegates to Trace2DLtd, which on eviction virtually dispatches to our overridden
 		// minXSearch()/maxXSearch() below (and to the unchanged Y searches).
 		return super.addPointInternal(p);
+	}
+
+	/**
+	 * In-place mutation of an existing point ({@code ITracePoint2D.setLocation}) fires a
+	 * {@code STATE_CHANGED} notification and can reorder the buffer arbitrarily, which the
+	 * insertion-time run tracking cannot see. Reset the run so the fast path stays off until
+	 * a full buffer of fresh monotonic insertions restores the guarantee. (Not used by the
+	 * Shimmer streaming paths, but keeps this class a safe drop-in for Trace2DLtd.)
+	 */
+	@Override
+	public void firePointChanged(final ITracePoint2D changed, final int state) {
+		if (state == ITracePoint2D.STATE_CHANGED) {
+			mAscendingRunLength = 0L;
+			mLastX = Double.NaN;
+		}
+		super.firePointChanged(changed, state);
 	}
 
 	@Override


### PR DESCRIPTION
## Summary

Fixes the stuttering/janky Live Data plots (worst at UHD) at their root causes in the jchart2d-based plotting layer. Diagnosis was verified against the actual jchart2d bytecode the build resolves (**3.3.2** — note the `libs/` folder carries a stale 3.2.2 jar):

- `Trace2DLtd.addPointInternal()` evicts the oldest ring-buffer point once full, and when the evicted point holds an extreme it runs a full linear rescan of the buffer (`minXSearch()` etc.). For time-series data X is monotonically increasing, so the evicted point *always* holds min-X → an O(buffer) scan on essentially every sample in steady state.
- That work happens inside `ATrace2D.addPoint()` while holding `synchronized(chart)` — the same monitor `Chart2D.paintComponent()` needs — so the data thread starves the Swing EDT, and the per-sample lock churn multiplies it.

## Changes (ShimmerDriverPC)

**New `Trace2DLtdMonotonicX` (extends `Trace2DLtd`)** — overrides `addPointInternal` and `minXSearch`/`maxXSearch`. When the ring buffer is provably sorted ascending by X (tracked via the run of consecutive non-decreasing-X insertions ≥ live buffer size), min/max X are answered in O(1) from the buffer's oldest/youngest elements. Anything that breaks the guarantee — backward X (rewind/replay), NaN-X discontinuity markers, in-place point mutation (`STATE_CHANGED`), buffer resize — falls back to the exact superclass scan until a full buffer of monotonic samples restores it. Y-range maintenance is deliberately left to the superclass (already amortized O(1) for random Y). Swapped in at the three live-plot construction sites in `BasicPlotManagerPC`; existing `(Trace2DLtd)` casts and the downsampler's runtime `setMaxSize()` calls are unaffected.

**Batched chart locking (`BasicPlotManagerPC`)** — `filterDataAndPlot`'s multi-trace loop now acquires the chart monitor once per sample instead of once per trace-point (Java monitors are reentrant, so the library's internal per-point lock becomes free), and a new `addPointsToTrace(trace, x[], y[], from, to)` adds FFT bins in bounded 256-point chunks per lock acquisition. The trace list is snapshotted *before* entering the chart monitor to preserve the app's existing `mListofTraces → chart` lock ordering (see review notes below).

## Cross-repo note

`Shimmer-Advance-API`'s `ShimmerDriverAdvancedPC` includes `:ShimmerDriverPC` from source in its `settings.gradle`, so Consensys picks this up with no changes on that side (verified compiling). ConsensysApps is not involved.

## Testing

- `gradle compileJava`: `ShimmerDriverPC` and `ShimmerDriverAdvancedPC` (Shimmer-Advance-API, building against these sources) both pass.
- Standalone correctness harness driving `Trace2DLtdMonotonicX` vs stock `Trace2DLtd` through a headless `Chart2D`: monotonic streaming past eviction, `setMaxSize` shrink+grow mid-stream, rewind/replay, repeated equal X — **11,596 min/max checks, 0 mismatches**.
- Needs real-hardware verification with live streaming (especially at UHD/4K): plots should scroll smoothly, UI should stay responsive while streaming, axis auto-scaling should look identical, and clearing/resizing traces mid-stream should behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JjgNkS6wtPkQUdK3KdHVdN

---
_Generated by [Claude Code](https://claude.ai/code/session_01JjgNkS6wtPkQUdK3KdHVdN)_