### PR TITLE
DEV-922 Upstream gen-2 default alignment into SensorLSM6DSV (supersedes #281)

### DIFF
--- a/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/sensors/SensorLSM6DSV.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/sensors/SensorLSM6DSV.java
@@ -261,8 +261,13 @@ public class SensorLSM6DSV extends AbstractSensor {
 	// matrix with cross-axis terms.
 	public static final double[][] DEFAULT_ALIGNMENT_LSM6DSV_ACCEL_GYRO =
 			UtilCalibration.matrixInverse3x3(APPLIED_ALIGNMENT_LSM6DSV_ACCEL_GYRO);
-	public static final double[][] DEFAULT_ALIGNMENT_LIS2MDL_MAG =
-			UtilCalibration.matrixInverse3x3(APPLIED_ALIGNMENT_LIS2MDL_MAG);
+	/* The mag applied matrix is its own inverse (an involution), but deriving it via
+	 * matrixInverse3x3 would stamp -0.0 into the zero entries (its determinant is -1),
+	 * which survives serialization and fails Arrays.deepEquals against 0.0 - so the
+	 * driver-form matrix is written out as a literal. ASM_PC_00032 guards that it
+	 * really is the inverse of the applied form. (The accel/gyro inverse above is
+	 * det +1 and computes canonical 0.0 entries, so it stays derived.) */
+	public static final double[][] DEFAULT_ALIGNMENT_LIS2MDL_MAG = {{1,0,0},{0,0,1},{0,1,0}};
 
 	// Accel sensitivity (LSB per m/s^2) = 32768/(FS_g*9.80665)
 	public static final double[][] SENS_ACCEL_2G  = {{1670.703,0,0},{0,1670.703,0},{0,0,1670.703}};

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/sensors/SensorLSM6DSV.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/sensors/SensorLSM6DSV.java
@@ -47,8 +47,12 @@ import com.shimmerresearch.sensors.lisxmdl.SensorLIS2MDL;
  * calibrated magnetometer output is in GAUSS, consistent with every other Shimmer
  * magnetometer and with the per-unit calibration the device stores.
  * <p>
- * Alignment is left as identity here and corrected by the file parser per hardware
- * revision; offsets are zero.
+ * Default alignment is the real sensor->ASM frame map (accel/gyro share the chip
+ * mounting; the LIS2MDL frame is left-handed), matching the web SDK's
+ * CALIBRATION_SENSORS_GEN2 and what verisense-device-console writes to the device.
+ * No hardware-revision gate is needed: every revision carrying this IMU (SR61 rev
+ * &gt;= 5, SR68 rev &gt;= 9) shares the same mounting, so a device that has an
+ * LSM6DSV is second-generation by construction. Offsets are zero.
  *
  * @author Mark Nolan
  */
@@ -237,12 +241,28 @@ public class SensorLSM6DSV extends AbstractSensor {
 			CompatibilityInfoForMaps.listOfCompatibleVersionInfoLSM6DSV);
 
 	// ----------------- Calibration Start -----------------------
-	// Identity alignment is a placeholder, NOT the real sensor->ASM map: the file
-	// parser overrides it per hardware revision at parse time (see
-	// CalibrationFileManager.applyGen2DefaultAlignment in the VerisenseDriver repo).
-	// Correcting it here as well would give two sources of truth for the same values.
 	public static final double[][] DEFAULT_OFFSET_VECTOR_LSM6DSV = {{0},{0},{0}};
-	public static final double[][] DEFAULT_ALIGNMENT_MATRIX_LSM6DSV = {{1,0,0},{0,1,0},{0,0,1}};
+
+	// Default alignment, stored first in APPLIED form - the sensor->ASM map,
+	// physical = applied . (raw - bias) / sens - so the literals below read exactly
+	// as verisense-device-console displays them and as the web SDK declares them
+	// (calibrationDefaults.ts, CALIBRATION_SENSORS_GEN2). Those two and this class
+	// must stay in agreement; they are the same physical mounting.
+	/** Applied sensor->ASM alignment for the LSM6DSV accel + gyro; det +1 (a proper rotation). */
+	public static final double[][] APPLIED_ALIGNMENT_LSM6DSV_ACCEL_GYRO = {{0,1,0},{0,0,1},{1,0,0}};
+	/** Applied sensor->ASM alignment for the LIS2MDL mag; its frame is left-handed, so det -1 (a reflection). */
+	public static final double[][] APPLIED_ALIGNMENT_LIS2MDL_MAG = {{1,0,0},{0,0,1},{0,1,0}};
+
+	// The driver stores the opposite convention: CalibDetailsKinematic holds AM and
+	// UtilCalibration computes AM^-1 . SM^-1 . (data - OV), so the matrices handed to
+	// the calibration blocks below are the INVERSES of the applied form. A true
+	// inverse, not a transpose: the two coincide only for orthogonal
+	// signed-permutation defaults like these, and would differ for a rig-measured
+	// matrix with cross-axis terms.
+	public static final double[][] DEFAULT_ALIGNMENT_LSM6DSV_ACCEL_GYRO =
+			UtilCalibration.matrixInverse3x3(APPLIED_ALIGNMENT_LSM6DSV_ACCEL_GYRO);
+	public static final double[][] DEFAULT_ALIGNMENT_LIS2MDL_MAG =
+			UtilCalibration.matrixInverse3x3(APPLIED_ALIGNMENT_LIS2MDL_MAG);
 
 	// Accel sensitivity (LSB per m/s^2) = 32768/(FS_g*9.80665)
 	public static final double[][] SENS_ACCEL_2G  = {{1670.703,0,0},{0,1670.703,0},{0,0,1670.703}};
@@ -274,35 +294,35 @@ public class SensorLSM6DSV extends AbstractSensor {
 
 	public CalibDetailsKinematic calibDetailsAccel2g = new CalibDetailsKinematic(
 			LSM6DSV_ACCEL_RANGE.RANGE_2G.configValue, LSM6DSV_ACCEL_RANGE.RANGE_2G.label,
-			DEFAULT_ALIGNMENT_MATRIX_LSM6DSV, SENS_ACCEL_2G, DEFAULT_OFFSET_VECTOR_LSM6DSV);
+			DEFAULT_ALIGNMENT_LSM6DSV_ACCEL_GYRO, SENS_ACCEL_2G, DEFAULT_OFFSET_VECTOR_LSM6DSV);
 	public CalibDetailsKinematic calibDetailsAccel4g = new CalibDetailsKinematic(
 			LSM6DSV_ACCEL_RANGE.RANGE_4G.configValue, LSM6DSV_ACCEL_RANGE.RANGE_4G.label,
-			DEFAULT_ALIGNMENT_MATRIX_LSM6DSV, SENS_ACCEL_4G, DEFAULT_OFFSET_VECTOR_LSM6DSV);
+			DEFAULT_ALIGNMENT_LSM6DSV_ACCEL_GYRO, SENS_ACCEL_4G, DEFAULT_OFFSET_VECTOR_LSM6DSV);
 	public CalibDetailsKinematic calibDetailsAccel8g = new CalibDetailsKinematic(
 			LSM6DSV_ACCEL_RANGE.RANGE_8G.configValue, LSM6DSV_ACCEL_RANGE.RANGE_8G.label,
-			DEFAULT_ALIGNMENT_MATRIX_LSM6DSV, SENS_ACCEL_8G, DEFAULT_OFFSET_VECTOR_LSM6DSV);
+			DEFAULT_ALIGNMENT_LSM6DSV_ACCEL_GYRO, SENS_ACCEL_8G, DEFAULT_OFFSET_VECTOR_LSM6DSV);
 	public CalibDetailsKinematic calibDetailsAccel16g = new CalibDetailsKinematic(
 			LSM6DSV_ACCEL_RANGE.RANGE_16G.configValue, LSM6DSV_ACCEL_RANGE.RANGE_16G.label,
-			DEFAULT_ALIGNMENT_MATRIX_LSM6DSV, SENS_ACCEL_16G, DEFAULT_OFFSET_VECTOR_LSM6DSV);
+			DEFAULT_ALIGNMENT_LSM6DSV_ACCEL_GYRO, SENS_ACCEL_16G, DEFAULT_OFFSET_VECTOR_LSM6DSV);
 
 	public CalibDetailsKinematic calibDetailsGyro125dps = new CalibDetailsKinematic(
 			LSM6DSV_GYRO_RANGE.RANGE_125DPS.configValue, LSM6DSV_GYRO_RANGE.RANGE_125DPS.label,
-			DEFAULT_ALIGNMENT_MATRIX_LSM6DSV, SENS_GYRO_125DPS, DEFAULT_OFFSET_VECTOR_LSM6DSV);
+			DEFAULT_ALIGNMENT_LSM6DSV_ACCEL_GYRO, SENS_GYRO_125DPS, DEFAULT_OFFSET_VECTOR_LSM6DSV);
 	public CalibDetailsKinematic calibDetailsGyro250dps = new CalibDetailsKinematic(
 			LSM6DSV_GYRO_RANGE.RANGE_250DPS.configValue, LSM6DSV_GYRO_RANGE.RANGE_250DPS.label,
-			DEFAULT_ALIGNMENT_MATRIX_LSM6DSV, SENS_GYRO_250DPS, DEFAULT_OFFSET_VECTOR_LSM6DSV);
+			DEFAULT_ALIGNMENT_LSM6DSV_ACCEL_GYRO, SENS_GYRO_250DPS, DEFAULT_OFFSET_VECTOR_LSM6DSV);
 	public CalibDetailsKinematic calibDetailsGyro500dps = new CalibDetailsKinematic(
 			LSM6DSV_GYRO_RANGE.RANGE_500DPS.configValue, LSM6DSV_GYRO_RANGE.RANGE_500DPS.label,
-			DEFAULT_ALIGNMENT_MATRIX_LSM6DSV, SENS_GYRO_500DPS, DEFAULT_OFFSET_VECTOR_LSM6DSV);
+			DEFAULT_ALIGNMENT_LSM6DSV_ACCEL_GYRO, SENS_GYRO_500DPS, DEFAULT_OFFSET_VECTOR_LSM6DSV);
 	public CalibDetailsKinematic calibDetailsGyro1000dps = new CalibDetailsKinematic(
 			LSM6DSV_GYRO_RANGE.RANGE_1000DPS.configValue, LSM6DSV_GYRO_RANGE.RANGE_1000DPS.label,
-			DEFAULT_ALIGNMENT_MATRIX_LSM6DSV, SENS_GYRO_1000DPS, DEFAULT_OFFSET_VECTOR_LSM6DSV);
+			DEFAULT_ALIGNMENT_LSM6DSV_ACCEL_GYRO, SENS_GYRO_1000DPS, DEFAULT_OFFSET_VECTOR_LSM6DSV);
 	public CalibDetailsKinematic calibDetailsGyro2000dps = new CalibDetailsKinematic(
 			LSM6DSV_GYRO_RANGE.RANGE_2000DPS.configValue, LSM6DSV_GYRO_RANGE.RANGE_2000DPS.label,
-			DEFAULT_ALIGNMENT_MATRIX_LSM6DSV, SENS_GYRO_2000DPS, DEFAULT_OFFSET_VECTOR_LSM6DSV);
+			DEFAULT_ALIGNMENT_LSM6DSV_ACCEL_GYRO, SENS_GYRO_2000DPS, DEFAULT_OFFSET_VECTOR_LSM6DSV);
 
 	public CalibDetailsKinematic calibDetailsMag = new CalibDetailsKinematic(
-			0, "Default", DEFAULT_ALIGNMENT_MATRIX_LSM6DSV, SENS_MAG, DEFAULT_OFFSET_VECTOR_LSM6DSV);
+			0, "Default", DEFAULT_ALIGNMENT_LIS2MDL_MAG, SENS_MAG, DEFAULT_OFFSET_VECTOR_LSM6DSV);
 
 	public CalibDetailsKinematic mCurrentCalibDetailsAccel = calibDetailsAccel4g;
 	public CalibDetailsKinematic mCurrentCalibDetailsGyro = calibDetailsGyro500dps;

--- a/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/sensors/SensorLSM6DSV.java
+++ b/ShimmerDriver/src/main/java/com/shimmerresearch/verisense/sensors/SensorLSM6DSV.java
@@ -28,6 +28,7 @@ import com.shimmerresearch.driverUtilities.ChannelDetails.CHANNEL_DATA_TYPE;
 import com.shimmerresearch.driverUtilities.ChannelDetails.CHANNEL_TYPE;
 import com.shimmerresearch.sensors.AbstractSensor;
 import com.shimmerresearch.sensors.ActionSetting;
+import com.shimmerresearch.sensors.lisxmdl.SensorLIS2MDL;
 
 /**
  * Second-generation Verisense IMU: LSM6DSV (accelerometer + gyroscope) with the
@@ -38,10 +39,16 @@ import com.shimmerresearch.sensors.ActionSetting;
  * tagged FIFO ([TAG_CNT][X][Y][Z]) interleaving the three streams; the byte-level
  * extraction + per-stream timestamping lives in
  * {@code VerisenseDevice.parseDataBlockDataLsm6dsv(...)}. This class provides the
- * channel definitions, configuration and calibration. Calibration matches the
- * firmware/SDK nominal model: value = raw / sensitivity (identity alignment,
- * zero offset) where sensitivity = 32768/(FS*9.80665) for accel, 32768/FS for
- * gyro and 1/0.15 for mag.
+ * channel definitions, configuration and calibration.
+ * <p>
+ * Sensitivities: 32768/(FS*9.80665) LSB per m/s^2 for accel, the ST angular-rate
+ * spec of 4.375 mdps/LSB at +-125 dps for gyro, and 667 LSB/Gauss for the LIS2MDL
+ * mag - the last taken from {@link SensorLIS2MDL} rather than duplicated here, so
+ * calibrated magnetometer output is in GAUSS, consistent with every other Shimmer
+ * magnetometer and with the per-unit calibration the device stores.
+ * <p>
+ * Alignment is left as identity here and corrected by the file parser per hardware
+ * revision; offsets are zero.
  *
  * @author Mark Nolan
  */
@@ -230,8 +237,10 @@ public class SensorLSM6DSV extends AbstractSensor {
 			CompatibilityInfoForMaps.listOfCompatibleVersionInfoLSM6DSV);
 
 	// ----------------- Calibration Start -----------------------
-	// Identity alignment + zero offset so calibrated = raw / sensitivity, matching
-	// the firmware/SDK nominal model (and the validated standalone decoder).
+	// Identity alignment is a placeholder, NOT the real sensor->ASM map: the file
+	// parser overrides it per hardware revision at parse time (see
+	// CalibrationFileManager.applyGen2DefaultAlignment in the VerisenseDriver repo).
+	// Correcting it here as well would give two sources of truth for the same values.
 	public static final double[][] DEFAULT_OFFSET_VECTOR_LSM6DSV = {{0},{0},{0}};
 	public static final double[][] DEFAULT_ALIGNMENT_MATRIX_LSM6DSV = {{1,0,0},{0,1,0},{0,0,1}};
 
@@ -251,8 +260,17 @@ public class SensorLSM6DSV extends AbstractSensor {
 	public static final double[][] SENS_GYRO_1000DPS = {{28.571428571,0,0},{0,28.571428571,0},{0,0,28.571428571}};
 	public static final double[][] SENS_GYRO_2000DPS = {{14.285714286,0,0},{0,14.285714286,0},{0,0,14.285714286}};
 
-	// Mag sensitivity (LSB per uT) = 1/0.15
-	public static final double[][] SENS_MAG = {{6.666667,0,0},{0,6.666667,0},{0,0,6.666667}};
+	// Mag sensitivity: taken from the LIS2MDL's own sensor class rather than
+	// re-declared here, because it is a property of the chip (1.5 mGauss/LSB) and not
+	// of the LSM6DSV sensor hub the samples arrive through. 667 LSB/Gauss, matching
+	// the firmware calibration seed (SC_LIS2MDL_MAG_SENS), the web SDK catalog, and
+	// every other Shimmer magnetometer (LSM303DLHC etc. are all LSB/Gauss).
+	//
+	// This was previously a local copy of 6.666667 = 1/0.15 LSB/uT, which made
+	// gen-2 magnetometer output 100x larger than every other Shimmer device for the
+	// same field, and 100x out of step with the per-unit calibration the device
+	// stores. Reference the shared constant so the two cannot diverge again.
+	public static final double[][] SENS_MAG = SensorLIS2MDL.DefaultSensitivityMatrixMagShimmer3r;
 
 	public CalibDetailsKinematic calibDetailsAccel2g = new CalibDetailsKinematic(
 			LSM6DSV_ACCEL_RANGE.RANGE_2G.configValue, LSM6DSV_ACCEL_RANGE.RANGE_2G.label,


### PR DESCRIPTION
## What

Makes the driver the **single source of truth** for gen-2 (LSM6DSV / LIS2MDL) default calibration, so the parse-time `applyGen2DefaultAlignment` override in ASM_PC/VerisenseDriver can be deleted before customer deployment instead of living on as a second copy of the same values.

Two commits:

1. **JC's mag-sensitivity fix, included verbatim from #281** (author preserved): `SENS_MAG` becomes the shared `SensorLIS2MDL` constant (667 LSB/Gauss) instead of a local 6.666667 LSB/µT copy — gen-2 mag output was 100× larger than every other Shimmer magnetometer and mislabeled (channels declare `LOCAL_FLUX`). Merging this PR carries that commit, so #281 can be closed as superseded.
2. **Alignment upstreaming**: the identity `DEFAULT_ALIGNMENT_MATRIX_LSM6DSV` placeholder is replaced by the real sensor→ASM matrices, stored in APPLIED form (reading exactly as verisense-device-console displays them and the web SDK declares them in `CALIBRATION_SENSORS_GEN2`), with the driver-form `AM` derived by a true matrix inverse since `UtilCalibration` applies `AM⁻¹`. Accel/gyro share the chip mounting (det +1); the LIS2MDL frame is left-handed (det −1).

No hardware-revision gate is needed: only 2nd-generation revisions (SR61≥5, SR68≥9) carry this IMU, so a device instantiating this sensor class is gen-2 by construction. The Shimmer3R's `com.shimmerresearch.sensors.lsm6dsv.SensorLSM6DSV` is a separate class and untouched.

## Validation

- ASM_PC `ASM_PC_00032_Gen2DefaultAlignment` (rewritten on the companion branch to guard the shipped defaults): 7/7 green against this branch.
- Full `ASM_PC_00005_VerisenseFileParserPC` (70 tests) against this branch + the companion override-removal: **only** the 14 Mag_CAL reference CSVs changed (the deliberate ÷100 Gauss fix, refs regenerated); every accel/gyro/GSR/light/skin-temp comparison stayed byte-identical — proving the alignment upstreaming itself changes no parsed output.

## Sequencing

1. Merge this; close #281 as superseded (its commit is included).
2. Jenkins-publish a new `shimmerdriver` artifact.
3. Merge ASM_PC `DEV-922_remove_gen2_alignment_override` (blocked until the artifact + version bump).

Jira: [DEV-922](https://shimmersensing.atlassian.net/browse/DEV-922)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DEV-922]: https://shimmersensing.atlassian.net/browse/DEV-922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ